### PR TITLE
feat: dynamic package assembly from scoring matrix

### DIFF
--- a/game-over-app/__tests__/setup.ts
+++ b/game-over-app/__tests__/setup.ts
@@ -124,3 +124,19 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
 });
+
+// Mock package images (avoids require() of .jpeg files in test env)
+vi.mock('@/constants/packageImages', () => ({
+  getPackageImage: vi.fn((citySlug: string, tier: string) => `mock-image-${citySlug}-${tier}`),
+  getCityImage: vi.fn((citySlug: string) => `mock-image-${citySlug}-essential`),
+  getEventImage: vi.fn((citySlug: string, packageSlug?: string) => `mock-image-${citySlug}`),
+  resolveImageSource: vi.fn((source: unknown) => source),
+  preloadPackageImages: vi.fn(() => Promise.resolve()),
+}));
+
+// Mock expo-asset
+vi.mock('expo-asset', () => ({
+  Asset: {
+    loadAsync: vi.fn(() => Promise.resolve()),
+  },
+}));

--- a/game-over-app/__tests__/unit/utils/packageAssembly.test.ts
+++ b/game-over-app/__tests__/unit/utils/packageAssembly.test.ts
@@ -92,4 +92,27 @@ describe('assemblePackages', () => {
     const unique = new Set(activityFeatures);
     expect(unique.size).toBe(3);
   });
+
+  it('features never duplicate across any profile (no dining repeated as activity)', () => {
+    // Low-activity profile — tests that even when the scoring matrix
+    // returns few highly-scored activities, features remain unique
+    const lowActivity = {
+      h1: 'relaxed' as const, h2: 'background' as const, h3: 'cooperative' as const,
+      h4: 'food' as const,    h5: 'indoor' as const,    h6: 'dinner_only' as const,
+      g1: '35+' as const,     g2: 'strangers' as const,  g3: 'low' as const,
+      g4: 'low' as const,     g5: 'relaxed' as const,    g6: [],
+    };
+    const pkgs = assemblePackages(lowActivity, 'berlin');
+    expect(pkgs).toHaveLength(3);
+    for (const pkg of pkgs) {
+      // No feature should appear more than once in a single tier
+      const seen = new Set(pkg.features);
+      expect(seen.size).toBe(pkg.features.length);
+      // All features must be non-empty strings
+      for (const f of pkg.features) {
+        expect(typeof f).toBe('string');
+        expect(f.length).toBeGreaterThan(0);
+      }
+    }
+  });
 });

--- a/game-over-app/__tests__/unit/utils/packageAssembly.test.ts
+++ b/game-over-app/__tests__/unit/utils/packageAssembly.test.ts
@@ -1,0 +1,95 @@
+import { assemblePackages } from '@/utils/packageAssembly';
+
+const FULL_ANSWERS = {
+  h1: 'active' as const,
+  h2: 'group' as const,
+  h3: 'cooperative' as const,
+  h4: 'experience' as const,
+  h5: 'indoor' as const,
+  h6: 'dinner_bar' as const,
+  g1: '26-30' as const,
+  g2: 'mixed' as const,
+  g3: 'medium' as const,
+  g4: 'social' as const,
+  g5: 'team_players' as const,
+  g6: ['action', 'nightlife'],
+};
+
+describe('assemblePackages', () => {
+  it('returns exactly 3 packages', () => {
+    expect(assemblePackages(FULL_ANSWERS, 'hannover')).toHaveLength(3);
+  });
+
+  it('returns tiers in order essential → classic → grand', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'hannover');
+    expect(pkgs[0].tier).toBe('essential');
+    expect(pkgs[1].tier).toBe('classic');
+    expect(pkgs[2].tier).toBe('grand');
+  });
+
+  it('S has 3 features, M has 4, L has 5', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'hannover');
+    expect(pkgs[0].features).toHaveLength(3);
+    expect(pkgs[1].features).toHaveLength(4);
+    expect(pkgs[2].features).toHaveLength(5);
+  });
+
+  it('classic tier has bestMatch true, others do not', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'hannover');
+    expect(pkgs[1].bestMatch).toBe(true);
+    expect(pkgs[0].bestMatch).toBeFalsy();
+    expect(pkgs[2].bestMatch).toBeFalsy();
+  });
+
+  it('ids include city slug', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'hamburg');
+    expect(pkgs[0].id).toBe('hamburg-essential');
+    expect(pkgs[1].id).toBe('hamburg-classic');
+    expect(pkgs[2].id).toBe('hamburg-grand');
+  });
+
+  it('uses defaults for null answers without throwing', () => {
+    const nullAnswers = {
+      h1: null, h2: null, h3: null, h4: null, h5: null, h6: null,
+      g1: null, g2: null, g3: null, g4: null, g5: null, g6: [],
+    };
+    const pkgs = assemblePackages(nullAnswers, 'berlin');
+    expect(pkgs).toHaveLength(3);
+    expect(pkgs[0].features).toHaveLength(3);
+    expect(pkgs[1].features).toHaveLength(4);
+    expect(pkgs[2].features).toHaveLength(5);
+  });
+
+  it('different profiles produce different top activities', () => {
+    const relaxed = { ...FULL_ANSWERS, h1: 'relaxed' as const, h4: 'food' as const, g5: 'relaxed' as const };
+    const action  = { ...FULL_ANSWERS, h1: 'action' as const,  h4: 'experience' as const, g5: 'competitive' as const };
+    const relaxedPkgs = assemblePackages(relaxed, 'hannover');
+    const actionPkgs  = assemblePackages(action, 'hannover');
+    expect(relaxedPkgs[0].features[0]).not.toBe(actionPkgs[0].features[0]);
+  });
+
+  it('prices match tier definitions', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'berlin');
+    expect(pkgs[0].price_per_person_cents).toBe(99_00);
+    expect(pkgs[1].price_per_person_cents).toBe(149_00);
+    expect(pkgs[2].price_per_person_cents).toBe(199_00);
+  });
+
+  it('all feature strings are non-empty strings', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'hannover');
+    for (const pkg of pkgs) {
+      for (const feature of pkg.features) {
+        expect(typeof feature).toBe('string');
+        expect(feature.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('L tier activities are all unique (no duplicates when pool has enough)', () => {
+    const pkgs = assemblePackages(FULL_ANSWERS, 'hannover');
+    const grand = pkgs[2];
+    const activityFeatures = grand.features.slice(0, 3);
+    const unique = new Set(activityFeatures);
+    expect(unique.size).toBe(3);
+  });
+});

--- a/game-over-app/__tests__/unit/utils/packageAssembly.test.ts
+++ b/game-over-app/__tests__/unit/utils/packageAssembly.test.ts
@@ -60,12 +60,15 @@ describe('assemblePackages', () => {
     expect(pkgs[2].features).toHaveLength(5);
   });
 
-  it('different profiles produce different top activities', () => {
+  it('different profiles produce different top activities (specific known winners)', () => {
+    // Relaxed + food-focused profile → Cocktail Making Course scores highest (22pts)
     const relaxed = { ...FULL_ANSWERS, h1: 'relaxed' as const, h4: 'food' as const, g5: 'relaxed' as const };
+    // Action + experience-focused + competitive → VR Arcade scores highest (23pts)
     const action  = { ...FULL_ANSWERS, h1: 'action' as const,  h4: 'experience' as const, g5: 'competitive' as const };
     const relaxedPkgs = assemblePackages(relaxed, 'hannover');
     const actionPkgs  = assemblePackages(action, 'hannover');
-    expect(relaxedPkgs[0].features[0]).not.toBe(actionPkgs[0].features[0]);
+    expect(relaxedPkgs[0].features[0]).toBe('Cocktail Workshop');
+    expect(actionPkgs[0].features[0]).toBe('VR Arcade');
   });
 
   it('prices match tier definitions', () => {

--- a/game-over-app/app/create-event/packages.tsx
+++ b/game-over-app/app/create-event/packages.tsx
@@ -33,7 +33,10 @@ function formatPrice(cents: number): string {
   return '\u20AC' + (cents / 100).toLocaleString('de-DE', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 }
 
+// pkg is either AssembledPackage (fallback) or a Supabase DB row — proper union typing
+// requires importing generated DB types and is deferred to a dedicated types refactor PR
 interface PackageSelectionCardProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pkg: any;
   index: number;
   isBestMatch: boolean;
@@ -484,8 +487,8 @@ export default function WizardStep4() {
     router.push(`/package/${packageId}`);
   }, [router]);
 
-  // Skip loading spinner for fallback cities — we have local data immediately
-  const hasFallbackData = !!(dbPackages && dbPackages.length > 0) || !!citySlug;
+  // Skip loading spinner when city is in our known set (we have local fallback data immediately)
+  const hasFallbackData = !!(dbPackages && dbPackages.length > 0) || CITY_UUID_TO_SLUG[cityId ?? ''] !== undefined;
   if (isLoading && !hasFallbackData) {
     return (
       <YStack flex={1} justifyContent="center" alignItems="center" backgroundColor="$background">

--- a/game-over-app/app/create-event/packages.tsx
+++ b/game-over-app/app/create-event/packages.tsx
@@ -33,11 +33,22 @@ function formatPrice(cents: number): string {
   return '\u20AC' + (cents / 100).toLocaleString('de-DE', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 }
 
-// pkg is either AssembledPackage (fallback) or a Supabase DB row — proper union typing
-// requires importing generated DB types and is deferred to a dedicated types refactor PR
+/** Minimal shape required by PackageSelectionCard — covers both AssembledPackage and DB rows */
+interface DisplayPackage {
+  id: string;
+  name: string;
+  tier: string;
+  price_per_person_cents?: number;
+  base_price_cents?: number;
+  hero_image_url?: unknown;
+  rating?: number;
+  review_count?: number;
+  features?: unknown[];
+  bestMatch?: boolean;
+}
+
 interface PackageSelectionCardProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  pkg: any;
+  pkg: DisplayPackage;
   index: number;
   isBestMatch: boolean;
   isSelected: boolean;
@@ -71,7 +82,7 @@ function PackageSelectionCard({
   const tierName = tierNames[pkg.tier] || pkg.name;
   const displayName = `${tierName} (${tierLabel})`;
 
-  const perPersonCents = pkg.price_per_person_cents || pkg.base_price_cents;
+  const perPersonCents = pkg.price_per_person_cents || pkg.base_price_cents || 0;
   const totalGroupCents = perPersonCents * participantCount;
   const displayPrice = pricingMode === 'per_person'
     ? formatPrice(perPersonCents)
@@ -81,11 +92,127 @@ function PackageSelectionCard({
   // Feature count by tier: S=3, M=4, L=5
   const featureLimit = pkg.tier === 'grand' ? 5 : pkg.tier === 'classic' ? 4 : 3;
   const features = Array.isArray(pkg.features)
-    ? pkg.features.filter((f: any): f is string => typeof f === 'string').slice(0, featureLimit)
+    ? (pkg.features as unknown[]).filter((f): f is string => typeof f === 'string').slice(0, featureLimit)
     : [];
 
   const imageSource = resolveImageSource(pkg.hero_image_url || getPackageImage('berlin', 'essential'));
   const cardHeight = isBestMatch ? 480 : 420;
+
+  // Shared inner content — identical between selected (KenBurns) and unselected (static image) branches
+  const cardContent = (
+    <>
+      {/* Badges */}
+      {(isBestMatch || isSelected) && (
+        <YStack position="absolute" top={16} left={16} gap="$1.5">
+          {isBestMatch && (
+            <XStack
+              backgroundColor={DARK_THEME.primary}
+              paddingHorizontal={12}
+              paddingVertical={6}
+              borderRadius={20}
+              gap="$1.5"
+              alignItems="center"
+              alignSelf="flex-start"
+            >
+              <Ionicons name="sparkles" size={12} color="white" />
+              <Text color="white" fontSize={11} fontWeight="600">
+                Recommendation based on preferences
+              </Text>
+            </XStack>
+          )}
+          {isSelected && (
+            <XStack
+              backgroundColor="rgba(71, 184, 129, 0.9)"
+              paddingHorizontal={12}
+              paddingVertical={6}
+              borderRadius={20}
+              gap="$1.5"
+              alignItems="center"
+              alignSelf="flex-start"
+            >
+              <Ionicons name="checkmark-circle" size={12} color="white" />
+              <Text color="white" fontSize={11} fontWeight="600">
+                Selected
+              </Text>
+            </XStack>
+          )}
+        </YStack>
+      )}
+
+      {/* Card Content */}
+      <YStack gap="$3">
+        {/* Title + Price */}
+        <XStack justifyContent="space-between" alignItems="flex-start">
+          <YStack flex={1}>
+            <Text fontSize={22} fontWeight="800" color="white">
+              {displayName}
+            </Text>
+            <XStack alignItems="center" gap="$1" marginTop="$1">
+              <Ionicons name="star" size={14} color="#FFB800" />
+              <Text fontSize={13} fontWeight="600" color="white">
+                {(pkg.rating || 4.5).toFixed(1)}
+              </Text>
+              <Text fontSize={13} color="rgba(255,255,255,0.7)">
+                ({pkg.review_count || 0} reviews)
+              </Text>
+            </XStack>
+          </YStack>
+          <YStack alignItems="flex-end">
+            <Text fontSize={24} fontWeight="800" color="white">
+              {displayPrice}
+            </Text>
+            <Text fontSize={12} color="rgba(255,255,255,0.7)">
+              {priceLabel}
+            </Text>
+          </YStack>
+        </XStack>
+
+        {/* Features */}
+        <YStack gap="$2">
+          {features.map((feature: string, i: number) => (
+            <XStack key={i} alignItems="center" gap="$2">
+              <Ionicons name="checkmark-circle" size={16} color={DARK_THEME.primary} />
+              <Text fontSize={14} color="rgba(255,255,255,0.9)">{feature}</Text>
+            </XStack>
+          ))}
+        </YStack>
+
+        {/* Actions */}
+        <XStack gap="$2" alignItems="center">
+          <Button
+            flex={1}
+            onPress={() => onSelect(pkg.id)}
+            variant={isSelected ? 'primary' : isBestMatch ? 'primary' : 'outline'}
+            testID={`select-package-${index}`}
+          >
+            {isSelected && isBestMatch
+              ? 'Recommendation Selected'
+              : isSelected
+              ? 'Currently Selected'
+              : isBestMatch
+              ? 'Select Recommended'
+              : 'Select Package'}
+          </Button>
+          <XStack
+            width={44}
+            height={44}
+            borderRadius="$full"
+            backgroundColor="rgba(255,255,255,0.15)"
+            alignItems="center"
+            justifyContent="center"
+            pressStyle={{ opacity: 0.7, backgroundColor: 'rgba(255,255,255,0.25)' }}
+            onPress={() => onViewDetails(pkg.id)}
+            testID={`details-package-${index}`}
+          >
+            <Ionicons name="information-circle-outline" size={22} color="white" />
+          </XStack>
+        </XStack>
+      </YStack>
+    </>
+  );
+
+  const gradientColors = ['transparent', 'rgba(0,0,0,0.4)', 'rgba(0,0,0,0.85)'] as const;
+  const gradientLocations = [0, 0.4, 1] as const;
 
   return (
     <YStack
@@ -101,246 +228,22 @@ function PackageSelectionCard({
       {isSelected ? (
         <KenBurnsImage source={imageSource} style={{ height: cardHeight, borderRadius: 16 }}>
           <LinearGradient
-            colors={['transparent', 'rgba(0,0,0,0.4)', 'rgba(0,0,0,0.85)']}
-            locations={[0, 0.4, 1]}
-            style={{
-              flex: 1,
-              borderRadius: 16,
-              justifyContent: 'flex-end',
-              padding: 20,
-            }}
+            colors={gradientColors}
+            locations={gradientLocations}
+            style={{ flex: 1, borderRadius: 16, justifyContent: 'flex-end', padding: 20 }}
           >
-            {/* Badges: show both Recommendation + Selected when applicable */}
-            {(isBestMatch || isSelected) && (
-              <YStack position="absolute" top={16} left={16} gap="$1.5">
-                {isBestMatch && (
-                  <XStack
-                    backgroundColor={DARK_THEME.primary}
-                    paddingHorizontal={12}
-                    paddingVertical={6}
-                    borderRadius={20}
-                    gap="$1.5"
-                    alignItems="center"
-                    alignSelf="flex-start"
-                  >
-                    <Ionicons name="sparkles" size={12} color="white" />
-                    <Text color="white" fontSize={11} fontWeight="600">
-                      Recommendation based on preferences
-                    </Text>
-                  </XStack>
-                )}
-                {isSelected && (
-                  <XStack
-                    backgroundColor="rgba(71, 184, 129, 0.9)"
-                    paddingHorizontal={12}
-                    paddingVertical={6}
-                    borderRadius={20}
-                    gap="$1.5"
-                    alignItems="center"
-                    alignSelf="flex-start"
-                  >
-                    <Ionicons name="checkmark-circle" size={12} color="white" />
-                    <Text color="white" fontSize={11} fontWeight="600">
-                      Selected
-                    </Text>
-                  </XStack>
-                )}
-              </YStack>
-            )}
-
-            {/* Card Content */}
-            <YStack gap="$3">
-              {/* Title + Price */}
-              <XStack justifyContent="space-between" alignItems="flex-start">
-                <YStack flex={1}>
-                  <Text fontSize={22} fontWeight="800" color="white">
-                    {displayName}
-                  </Text>
-                  <XStack alignItems="center" gap="$1" marginTop="$1">
-                    <Ionicons name="star" size={14} color="#FFB800" />
-                    <Text fontSize={13} fontWeight="600" color="white">
-                      {(pkg.rating || 4.5).toFixed(1)}
-                    </Text>
-                    <Text fontSize={13} color="rgba(255,255,255,0.7)">
-                      ({pkg.review_count || 0} reviews)
-                    </Text>
-                  </XStack>
-                </YStack>
-                <YStack alignItems="flex-end">
-                  <Text fontSize={24} fontWeight="800" color="white">
-                    {displayPrice}
-                  </Text>
-                  <Text fontSize={12} color="rgba(255,255,255,0.7)">
-                    {priceLabel}
-                  </Text>
-                </YStack>
-              </XStack>
-
-              {/* Features */}
-              <YStack gap="$2">
-                {features.map((feature: string, i: number) => (
-                  <XStack key={i} alignItems="center" gap="$2">
-                    <Ionicons name="checkmark-circle" size={16} color={DARK_THEME.primary} />
-                    <Text fontSize={14} color="rgba(255,255,255,0.9)">{feature}</Text>
-                  </XStack>
-                ))}
-              </YStack>
-
-              {/* Actions */}
-              <XStack gap="$2" alignItems="center">
-                <Button
-                  flex={1}
-                  onPress={() => onSelect(pkg.id)}
-                  variant={isSelected ? 'primary' : isBestMatch ? 'primary' : 'outline'}
-                  testID={`select-package-${index}`}
-                >
-                  {isSelected && isBestMatch
-                    ? 'Recommendation Selected'
-                    : isSelected
-                    ? 'Currently Selected'
-                    : isBestMatch
-                    ? 'Select Recommended'
-                    : 'Select Package'}
-                </Button>
-                <XStack
-                  width={44}
-                  height={44}
-                  borderRadius="$full"
-                  backgroundColor="rgba(255,255,255,0.15)"
-                  alignItems="center"
-                  justifyContent="center"
-                  pressStyle={{ opacity: 0.7, backgroundColor: 'rgba(255,255,255,0.25)' }}
-                  onPress={() => onViewDetails(pkg.id)}
-                  testID={`details-package-${index}`}
-                >
-                  <Ionicons name="information-circle-outline" size={22} color="white" />
-                </XStack>
-              </XStack>
-
-            </YStack>
+            {cardContent}
           </LinearGradient>
         </KenBurnsImage>
       ) : (
         <View style={{ height: cardHeight, borderRadius: 16, overflow: 'hidden' }}>
           <Image source={imageSource} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
           <LinearGradient
-            colors={['transparent', 'rgba(0,0,0,0.4)', 'rgba(0,0,0,0.85)']}
-            locations={[0, 0.4, 1]}
-            style={{
-              ...StyleSheet.absoluteFillObject,
-              borderRadius: 16,
-              justifyContent: 'flex-end',
-              padding: 20,
-            }}
+            colors={gradientColors}
+            locations={gradientLocations}
+            style={{ ...StyleSheet.absoluteFillObject, borderRadius: 16, justifyContent: 'flex-end', padding: 20 }}
           >
-            {/* Badges: show both Recommendation + Selected when applicable */}
-            {(isBestMatch || isSelected) && (
-              <YStack position="absolute" top={16} left={16} gap="$1.5">
-                {isBestMatch && (
-                  <XStack
-                    backgroundColor={DARK_THEME.primary}
-                    paddingHorizontal={12}
-                    paddingVertical={6}
-                    borderRadius={20}
-                    gap="$1.5"
-                    alignItems="center"
-                    alignSelf="flex-start"
-                  >
-                    <Ionicons name="sparkles" size={12} color="white" />
-                    <Text color="white" fontSize={11} fontWeight="600">
-                      Recommendation based on preferences
-                    </Text>
-                  </XStack>
-                )}
-                {isSelected && (
-                  <XStack
-                    backgroundColor="rgba(71, 184, 129, 0.9)"
-                    paddingHorizontal={12}
-                    paddingVertical={6}
-                    borderRadius={20}
-                    gap="$1.5"
-                    alignItems="center"
-                    alignSelf="flex-start"
-                  >
-                    <Ionicons name="checkmark-circle" size={12} color="white" />
-                    <Text color="white" fontSize={11} fontWeight="600">
-                      Selected
-                    </Text>
-                  </XStack>
-                )}
-              </YStack>
-            )}
-
-            {/* Card Content */}
-            <YStack gap="$3">
-              {/* Title + Price */}
-              <XStack justifyContent="space-between" alignItems="flex-start">
-                <YStack flex={1}>
-                  <Text fontSize={22} fontWeight="800" color="white">
-                    {displayName}
-                  </Text>
-                  <XStack alignItems="center" gap="$1" marginTop="$1">
-                    <Ionicons name="star" size={14} color="#FFB800" />
-                    <Text fontSize={13} fontWeight="600" color="white">
-                      {(pkg.rating || 4.5).toFixed(1)}
-                    </Text>
-                    <Text fontSize={13} color="rgba(255,255,255,0.7)">
-                      ({pkg.review_count || 0} reviews)
-                    </Text>
-                  </XStack>
-                </YStack>
-                <YStack alignItems="flex-end">
-                  <Text fontSize={24} fontWeight="800" color="white">
-                    {displayPrice}
-                  </Text>
-                  <Text fontSize={12} color="rgba(255,255,255,0.7)">
-                    {priceLabel}
-                  </Text>
-                </YStack>
-              </XStack>
-
-              {/* Features */}
-              <YStack gap="$2">
-                {features.map((feature: string, i: number) => (
-                  <XStack key={i} alignItems="center" gap="$2">
-                    <Ionicons name="checkmark-circle" size={16} color={DARK_THEME.primary} />
-                    <Text fontSize={14} color="rgba(255,255,255,0.9)">{feature}</Text>
-                  </XStack>
-                ))}
-              </YStack>
-
-              {/* Actions */}
-              <XStack gap="$2" alignItems="center">
-                <Button
-                  flex={1}
-                  onPress={() => onSelect(pkg.id)}
-                  variant={isSelected ? 'primary' : isBestMatch ? 'primary' : 'outline'}
-                  testID={`select-package-${index}`}
-                >
-                  {isSelected && isBestMatch
-                    ? 'Recommendation Selected'
-                    : isSelected
-                    ? 'Currently Selected'
-                    : isBestMatch
-                    ? 'Select Recommended'
-                    : 'Select Package'}
-                </Button>
-                <XStack
-                  width={44}
-                  height={44}
-                  borderRadius="$full"
-                  backgroundColor="rgba(255,255,255,0.15)"
-                  alignItems="center"
-                  justifyContent="center"
-                  pressStyle={{ opacity: 0.7, backgroundColor: 'rgba(255,255,255,0.25)' }}
-                  onPress={() => onViewDetails(pkg.id)}
-                  testID={`details-package-${index}`}
-                >
-                  <Ionicons name="information-circle-outline" size={22} color="white" />
-                </XStack>
-              </XStack>
-
-            </YStack>
+            {cardContent}
           </LinearGradient>
         </View>
       )}
@@ -394,15 +297,15 @@ export default function WizardStep4() {
     ? dbPackages
     : assembledPackages;
   const packages = [...rawPackages].sort(
-    (a: any, b: any) => (TIER_ORDER[a.tier] ?? 1) - (TIER_ORDER[b.tier] ?? 1)
+    (a, b) => (TIER_ORDER[a.tier] ?? 1) - (TIER_ORDER[b.tier] ?? 1)
   );
 
   // Auto-select best match (classic/M tier) when packages load and nothing is selected
   const didAutoSelect = useRef(false);
   useEffect(() => {
     if (didAutoSelect.current || selectedPackageId || packages.length === 0) return;
-    const bestMatch = packages.find((p: any) => p.bestMatch === true) ||
-                      packages.find((p: any) => p.tier === 'classic');
+    const bestMatch = packages.find((p) => (p as DisplayPackage).bestMatch === true) ||
+                      packages.find((p) => p.tier === 'classic');
     if (bestMatch) {
       setSelectedPackageId(bestMatch.id);
       didAutoSelect.current = true;
@@ -432,7 +335,7 @@ export default function WizardStep4() {
         return;
       }
       // Store hero image reference: remote URL string or local package slug (e.g. "hamburg-classic")
-      const selectedPkg = packages.find((p: any) => p.id === wizardState.selectedPackageId);
+      const selectedPkg = packages.find((p) => p.id === wizardState.selectedPackageId);
       const heroUrl = typeof selectedPkg?.hero_image_url === 'string'
         ? selectedPkg.hero_image_url
         : (typeof selectedPkg?.id === 'string' ? selectedPkg.id : null);
@@ -560,12 +463,12 @@ export default function WizardStep4() {
 
         {/* Package Cards */}
         {packages && packages.length > 0 ? (
-          packages.map((pkg: any, index: number) => (
+          packages.map((pkg, index) => (
             <PackageSelectionCard
               key={pkg.id}
-              pkg={pkg}
+              pkg={pkg as DisplayPackage}
               index={index}
-              isBestMatch={pkg.bestMatch === true || (!rawPackages.some((p: any) => p.bestMatch) && pkg.tier === 'classic')}
+              isBestMatch={(pkg as DisplayPackage).bestMatch === true || (!rawPackages.some((p) => (p as DisplayPackage).bestMatch) && pkg.tier === 'classic')}
               isSelected={selectedPackageId === pkg.id}
               pricingMode={pricingMode}
               participantCount={participantCount}

--- a/game-over-app/app/create-event/packages.tsx
+++ b/game-over-app/app/create-event/packages.tsx
@@ -3,7 +3,7 @@
  * Full-height cards with pricing toggle, best match highlight
  */
 
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { ScrollView, Alert, Image, View, StyleSheet } from 'react-native';
 import { KenBurnsImage } from '@/components/ui/KenBurnsImage';
 import { useRouter } from 'expo-router';
@@ -17,16 +17,8 @@ import { WizardFooter } from '@/components/ui/WizardFooter';
 import { DARK_THEME } from '@/constants/theme';
 import { getPackageImage, resolveImageSource } from '@/constants/packageImages';
 import { LinearGradient } from 'expo-linear-gradient';
-import { supabase } from '@/lib/supabase/client';
 import { setDesiredParticipants } from '@/lib/participantCountCache';
 import { assemblePackages } from '@/utils/packageAssembly';
-
-// Standard per-person pricing: S=€99, M=€149, L=€199
-const TIER_PRICE_PER_PERSON: Record<string, number> = {
-  essential: 99_00,
-  classic: 149_00,
-  grand: 199_00,
-};
 
 // Feature counts by tier: S=3, M=4, L=5
 // Fallback packages when DB returns empty (for Berlin, Hamburg, Hannover)
@@ -383,15 +375,21 @@ export default function WizardStep4() {
   // Sort order: S (essential) → M (classic/recommended) → L (grand)
   const TIER_ORDER: Record<string, number> = { essential: 0, classic: 1, grand: 2 };
   const citySlug = cityId ? (CITY_UUID_TO_SLUG[cityId] || 'berlin') : 'berlin';
-  const wizardAnswers = {
+  const assembledPackages = useMemo(() => assemblePackages({
     h1: energyLevel, h2: spotlightComfort, h3: competitionStyle,
     h4: enjoymentType, h5: indoorOutdoor, h6: eveningStyle,
     g1: averageAge, g2: groupCohesion, g3: fitnessLevel,
     g4: drinkingCulture, g5: groupDynamic, g6: groupVibe,
-  };
+  }, citySlug), [
+    citySlug,
+    energyLevel, spotlightComfort, competitionStyle,
+    enjoymentType, indoorOutdoor, eveningStyle,
+    averageAge, groupCohesion, fitnessLevel,
+    drinkingCulture, groupDynamic, groupVibe,
+  ]);
   const rawPackages = (dbPackages && dbPackages.length > 0)
     ? dbPackages
-    : assemblePackages(wizardAnswers, citySlug);
+    : assembledPackages;
   const packages = [...rawPackages].sort(
     (a: any, b: any) => (TIER_ORDER[a.tier] ?? 1) - (TIER_ORDER[b.tier] ?? 1)
   );

--- a/game-over-app/app/create-event/packages.tsx
+++ b/game-over-app/app/create-event/packages.tsx
@@ -19,6 +19,7 @@ import { getPackageImage, resolveImageSource } from '@/constants/packageImages';
 import { LinearGradient } from 'expo-linear-gradient';
 import { supabase } from '@/lib/supabase/client';
 import { setDesiredParticipants } from '@/lib/participantCountCache';
+import { assemblePackages } from '@/utils/packageAssembly';
 
 // Standard per-person pricing: S=€99, M=€149, L=€199
 const TIER_PRICE_PER_PERSON: Record<string, number> = {
@@ -34,116 +35,6 @@ const CITY_UUID_TO_SLUG: Record<string, string> = {
   '550e8400-e29b-41d4-a716-446655440101': 'berlin',
   '550e8400-e29b-41d4-a716-446655440102': 'hamburg',
   '550e8400-e29b-41d4-a716-446655440103': 'hannover',
-};
-const FALLBACK_PACKAGES: Record<string, any[]> = {
-  berlin: [
-    {
-      id: 'berlin-classic',
-      name: 'Berlin Classic',
-      tier: 'classic',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.classic,
-      hero_image_url: getPackageImage('berlin', 'classic'),
-      rating: 4.8,
-      review_count: 127,
-      features: ['VIP nightlife access', 'Private party bus', 'Professional photographer', 'Welcome drinks package'],
-      description: 'The ideal balance of nightlife, culture, and unforgettable moments in Berlin.',
-      bestMatch: true,
-    },
-    {
-      id: 'berlin-essential',
-      name: 'Berlin Essential',
-      tier: 'essential',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.essential,
-      hero_image_url: getPackageImage('berlin', 'essential'),
-      rating: 4.5,
-      review_count: 89,
-      features: ['Bar hopping tour', 'Welcome drinks', 'Group coordination'],
-      description: 'A solid party plan with all the essentials covered.',
-    },
-    {
-      id: 'berlin-grand',
-      name: 'Berlin Grand',
-      tier: 'grand',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.grand,
-      hero_image_url: getPackageImage('berlin', 'grand'),
-      rating: 4.9,
-      review_count: 42,
-      features: ['Luxury suite', 'Private chef dinner', 'Spa & wellness package', 'VIP club access', 'Private chauffeur'],
-      description: 'The ultimate premium experience with luxury at every turn.',
-    },
-  ],
-  hamburg: [
-    {
-      id: 'hamburg-classic',
-      name: 'Hamburg Classic',
-      tier: 'classic',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.classic,
-      hero_image_url: getPackageImage('hamburg', 'classic'),
-      rating: 4.7,
-      review_count: 98,
-      features: ['Reeperbahn nightlife tour', 'Harbor cruise', 'Professional photographer', 'Reserved bar area'],
-      description: 'Experience Hamburg\'s legendary nightlife and harbor in style.',
-      bestMatch: true,
-    },
-    {
-      id: 'hamburg-essential',
-      name: 'Hamburg Essential',
-      tier: 'essential',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.essential,
-      hero_image_url: getPackageImage('hamburg', 'essential'),
-      rating: 4.4,
-      review_count: 64,
-      features: ['Guided bar tour', 'Welcome cocktails', 'Group planning'],
-      description: 'A fun, well-organized Hamburg party experience.',
-    },
-    {
-      id: 'hamburg-grand',
-      name: 'Hamburg Grand',
-      tier: 'grand',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.grand,
-      hero_image_url: getPackageImage('hamburg', 'grand'),
-      rating: 4.9,
-      review_count: 31,
-      features: ['Elbphilharmonie VIP event', 'Private yacht dinner', 'Luxury hotel suite', 'Spa & wellness day', 'Premium bottle service'],
-      description: 'Premium Hamburg experience with exclusive venues and luxury service.',
-    },
-  ],
-  hannover: [
-    {
-      id: 'hannover-classic',
-      name: 'Hannover Classic',
-      tier: 'classic',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.classic,
-      hero_image_url: getPackageImage('hannover', 'classic'),
-      rating: 4.6,
-      review_count: 73,
-      features: ['Craft beer experience', 'Go-kart racing', 'Professional photographer', 'Welcome dinner'],
-      description: 'An action-packed celebration in the heart of Hannover.',
-      bestMatch: true,
-    },
-    {
-      id: 'hannover-essential',
-      name: 'Hannover Essential',
-      tier: 'essential',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.essential,
-      hero_image_url: getPackageImage('hannover', 'essential'),
-      rating: 4.3,
-      review_count: 51,
-      features: ['City adventure tour', 'Welcome drinks', 'Group coordination'],
-      description: 'A great time in Hannover without breaking the bank.',
-    },
-    {
-      id: 'hannover-grand',
-      name: 'Hannover Grand',
-      tier: 'grand',
-      price_per_person_cents: TIER_PRICE_PER_PERSON.grand,
-      hero_image_url: getPackageImage('hannover', 'grand'),
-      rating: 4.8,
-      review_count: 28,
-      features: ['Herrenhausen Gardens gala', 'Private chef dinner', 'Spa & wellness day', 'VIP nightlife access', 'Luxury hotel suite'],
-      description: 'Exclusive Hannover experience with private gala and luxury wellness.',
-    },
-  ],
 };
 
 function formatPrice(cents: number): string {
@@ -469,8 +360,8 @@ export default function WizardStep4() {
   const wizardState = useWizardStore();
   const {
     cityId,
-    energyLevel,
-    groupVibe,
+    energyLevel, spotlightComfort, competitionStyle, enjoymentType, indoorOutdoor, eveningStyle,
+    averageAge, groupCohesion, fitnessLevel, drinkingCulture, groupDynamic, groupVibe,
     participantCount,
     selectedPackageId,
     setSelectedPackageId,
@@ -491,10 +382,16 @@ export default function WizardStep4() {
   // Resolve UUID to slug for fallback lookup
   // Sort order: S (essential) → M (classic/recommended) → L (grand)
   const TIER_ORDER: Record<string, number> = { essential: 0, classic: 1, grand: 2 };
-  const citySlug = cityId ? (CITY_UUID_TO_SLUG[cityId] || cityId) : null;
+  const citySlug = cityId ? (CITY_UUID_TO_SLUG[cityId] || 'berlin') : 'berlin';
+  const wizardAnswers = {
+    h1: energyLevel, h2: spotlightComfort, h3: competitionStyle,
+    h4: enjoymentType, h5: indoorOutdoor, h6: eveningStyle,
+    g1: averageAge, g2: groupCohesion, g3: fitnessLevel,
+    g4: drinkingCulture, g5: groupDynamic, g6: groupVibe,
+  };
   const rawPackages = (dbPackages && dbPackages.length > 0)
     ? dbPackages
-    : (citySlug ? FALLBACK_PACKAGES[citySlug] || [] : []);
+    : assemblePackages(wizardAnswers, citySlug);
   const packages = [...rawPackages].sort(
     (a: any, b: any) => (TIER_ORDER[a.tier] ?? 1) - (TIER_ORDER[b.tier] ?? 1)
   );
@@ -590,7 +487,7 @@ export default function WizardStep4() {
   }, [router]);
 
   // Skip loading spinner for fallback cities — we have local data immediately
-  const hasFallbackData = !!(citySlug && FALLBACK_PACKAGES[citySlug]);
+  const hasFallbackData = !!(dbPackages && dbPackages.length > 0) || !!citySlug;
   if (isLoading && !hasFallbackData) {
     return (
       <YStack flex={1} justifyContent="center" alignItems="center" backgroundColor="$background">

--- a/game-over-app/app/package/[id].tsx
+++ b/game-over-app/app/package/[id].tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/Button';
 import { DARK_THEME } from '@/constants/theme';
 import { getPackageImage, resolveImageSource } from '@/constants/packageImages';
 import { useTranslation } from '@/i18n';
+import { assemblePackages } from '@/utils/packageAssembly';
 import type { Json } from '@/lib/supabase/types';
 
 const TIER_PRICE_PER_PERSON: Record<string, number> = {
@@ -37,6 +38,16 @@ const FALLBACK_PACKAGE_MAP: Record<string, any> = {
   'hannover-essential': { id: 'hannover-essential', name: 'Hannover Essential', tier: 'essential', base_price_cents: 99_00, price_per_person_cents: 99_00, rating: 4.3, review_count: 51, features: ['City adventure tour', 'Welcome drinks', 'Group coordination'], description: 'A great time in Hannover without breaking the bank.', hero_image_url: getPackageImage('hannover', 'essential') },
   'hannover-grand': { id: 'hannover-grand', name: 'Hannover Grand', tier: 'grand', base_price_cents: 199_00, price_per_person_cents: 199_00, rating: 4.8, review_count: 28, features: ['Herrenhausen Gardens gala', 'Private chef dinner', 'Spa & wellness day', 'VIP nightlife access', 'Luxury hotel suite'], description: 'Exclusive Hannover experience with private gala and luxury wellness.', hero_image_url: getPackageImage('hannover', 'grand') },
 };
+
+const CITY_SLUGS = ['berlin', 'hamburg', 'hannover'];
+const TIER_SLUGS = ['essential', 'classic', 'grand'];
+function isAssembledPackageId(id: string): boolean {
+  const parts = id.split('-');
+  if (parts.length < 2) return false;
+  const city = parts[0];
+  const tier = parts[parts.length - 1];
+  return CITY_SLUGS.includes(city) && TIER_SLUGS.includes(tier);
+}
 
 const toStringArray = (value: Json | null | undefined): string[] => {
   if (Array.isArray(value)) {
@@ -204,8 +215,32 @@ export default function PackageDetailsScreen() {
   const { t } = useTranslation();
   const { data: dbPkg, isLoading } = usePackage(id);
 
-  // Use DB package if available, otherwise check fallback data
-  const pkg = dbPkg || FALLBACK_PACKAGE_MAP[id];
+  // Read wizard answers to assemble dynamic package when needed
+  const wizardState = useWizardStore();
+  const {
+    cityId,
+    energyLevel, spotlightComfort, competitionStyle, enjoymentType, indoorOutdoor, eveningStyle,
+    averageAge, groupCohesion, fitnessLevel, drinkingCulture, groupDynamic, groupVibe,
+  } = wizardState;
+
+  // If DB returned nothing and the ID matches a city-tier pattern, assemble dynamically from wizard answers
+  let assembledPkg: ReturnType<typeof assemblePackages>[number] | undefined;
+  if (!dbPkg && id && isAssembledPackageId(id)) {
+    const parts = id.split('-');
+    const citySlug = parts[0];
+    const tierSlug = parts[parts.length - 1];
+    const resolvedCitySlug = citySlug || (cityId ? cityId : 'berlin');
+    const assembled = assemblePackages({
+      h1: energyLevel, h2: spotlightComfort, h3: competitionStyle,
+      h4: enjoymentType, h5: indoorOutdoor, h6: eveningStyle,
+      g1: averageAge, g2: groupCohesion, g3: fitnessLevel,
+      g4: drinkingCulture, g5: groupDynamic, g6: groupVibe,
+    }, resolvedCitySlug);
+    assembledPkg = assembled.find(p => p.tier === tierSlug);
+  }
+
+  // Use DB package if available, then dynamically assembled package, then static fallback
+  const pkg = dbPkg || assembledPkg || FALLBACK_PACKAGE_MAP[id];
 
   if (isLoading && !pkg) {
     return (

--- a/game-over-app/src/utils/packageAssembly.ts
+++ b/game-over-app/src/utils/packageAssembly.ts
@@ -6,6 +6,7 @@
  */
 
 import { scoreActivities } from './packageMatching';
+import type { ImageSourcePropType } from 'react-native';
 import { getPackageImage } from '@/constants/packageImages';
 import type {
   HonoreeEnergyLevel, SpotlightComfort, CompetitionStyle,
@@ -35,7 +36,7 @@ export interface AssembledPackage {
   name: string;
   tier: 'essential' | 'classic' | 'grand';
   price_per_person_cents: number;
-  hero_image_url: any;
+  hero_image_url: ImageSourcePropType;
   rating: number;
   review_count: number;
   features: string[];
@@ -105,6 +106,21 @@ const ACTIVITY_NAMES: Record<string, string> = {
   'Gin Tasting + Botanicals':      'Gin Tasting',
   'Cocktail Making Course':        'Cocktail Workshop',
   'BBQ Grill & Chill':             'BBQ & Grill',
+  // Additional activities from scoring matrix
+  'Go-Karting':                    'Go-Karting',
+  'VR Arcade':                     'VR Arcade',
+  'Axe Throwing':                  'Axe Throwing',
+  'Escape Room':                   'Escape Room',
+  'Trampoline Park':               'Trampoline Park',
+  'Cooking Class':                 'Cooking Class',
+  'Guided Bike Tour':              'Guided Bike Tour',
+  'Kayak / SUP':                   'Kayak & SUP',
+  'Creative Workshop':             'Creative Workshop',
+  'Dance Class':                   'Dance Class',
+  'Darts Tournament':              'Darts Tournament',
+  'Sports Viewing':                'Sports Viewing',
+  'Food Tour':                     'Food Tour',
+  'Wine Tasting':                  'Wine Tasting',
 };
 
 const DINING_NAMES: Record<string, string> = {
@@ -114,6 +130,9 @@ const DINING_NAMES: Record<string, string> = {
   'Pizza Party + Craft Beer':          'Pizza & Craft Beer Dinner',
   "Private Dining Room + Chef's Menu": 'Private Chef Dinner',
   'Beer Hall / Platter Night':         'Beer Hall Dinner',
+  'Brunch Buffet':                     'Brunch Buffet',
+  'Steakhouse Dinner':                 'Steakhouse Dinner',
+  'Sushi Dinner':                      'Sushi Dinner',
 };
 
 const BAR_NAMES: Record<string, string> = {
@@ -174,9 +193,11 @@ export function assemblePackages(answers: WizardAnswers, citySlug: string): Asse
   const topDining = diningSlot ? diningName(diningSlot.name) : 'Restaurant Dinner';
   const topBar    = barSlot    ? barName(barSlot.name)       : 'Bar Night with Drinks';
 
-  // Deduplicate activities, pad with last if fewer than 3
+  // Deduplicate activities; pad with generic fallbacks if pool has fewer than 3
+  const GENERIC_ACTIVITIES = ['City Experience', 'Group Activity', 'Team Challenge'];
   const uniqueActivities = [...new Set(activities)];
-  const act = (i: number) => uniqueActivities[i] ?? uniqueActivities[uniqueActivities.length - 1] ?? topDining;
+  const pool = uniqueActivities.length > 0 ? uniqueActivities : GENERIC_ACTIVITIES;
+  const act = (i: number) => pool[i] ?? pool[pool.length - 1];
 
   const city = citySlug.charAt(0).toUpperCase() + citySlug.slice(1);
 

--- a/game-over-app/src/utils/packageAssembly.ts
+++ b/game-over-app/src/utils/packageAssembly.ts
@@ -112,7 +112,7 @@ const DINING_NAMES: Record<string, string> = {
   'Tapas / Shared Plates':             'Tapas Dinner',
   'BBQ Ribs + Beer Tower':             'BBQ Dinner',
   'Pizza Party + Craft Beer':          'Pizza & Craft Beer Dinner',
-  "Private Dining Room + Chef's Menu": 'Private Dining Experience',
+  "Private Dining Room + Chef's Menu": 'Private Chef Dinner',
   'Beer Hall / Platter Night':         'Beer Hall Dinner',
 };
 

--- a/game-over-app/src/utils/packageAssembly.ts
+++ b/game-over-app/src/utils/packageAssembly.ts
@@ -1,0 +1,199 @@
+/**
+ * Package Assembly
+ * Builds 3 dynamic packages (S/M/L) from wizard questionnaire answers.
+ * Uses the scoring matrix to pick the best-matched activities, dining, and bar slots.
+ * Provider names are NOT included here — they are revealed after full payment.
+ */
+
+import { scoreActivities } from './packageMatching';
+import { getPackageImage } from '@/constants/packageImages';
+import type {
+  HonoreeEnergyLevel, SpotlightComfort, CompetitionStyle,
+  EnjoymentType, IndoorOutdoor, EveningStyle,
+  AgeRange, GroupCohesion, FitnessLevel, DrinkingCulture, GroupDynamic,
+} from '@/stores/wizardStore';
+
+// --- Types ---
+
+export interface WizardAnswers {
+  h1: HonoreeEnergyLevel | null;
+  h2: SpotlightComfort | null;
+  h3: CompetitionStyle | null;
+  h4: EnjoymentType | null;
+  h5: IndoorOutdoor | null;
+  h6: EveningStyle | null;
+  g1: AgeRange | null;
+  g2: GroupCohesion | null;
+  g3: FitnessLevel | null;
+  g4: DrinkingCulture | null;
+  g5: GroupDynamic | null;
+  g6: string[];
+}
+
+export interface AssembledPackage {
+  id: string;
+  name: string;
+  tier: 'essential' | 'classic' | 'grand';
+  price_per_person_cents: number;
+  hero_image_url: any;
+  rating: number;
+  review_count: number;
+  features: string[];
+  description: string;
+  bestMatch?: boolean;
+}
+
+// --- Defaults (used when wizard answers are incomplete) ---
+
+const DEFAULTS = {
+  h1: 'active'       as HonoreeEnergyLevel,
+  h2: 'group'        as SpotlightComfort,
+  h3: 'cooperative'  as CompetitionStyle,
+  h4: 'experience'   as EnjoymentType,
+  h5: 'mix'          as IndoorOutdoor,
+  h6: 'dinner_bar'   as EveningStyle,
+  g1: '26-30'        as AgeRange,
+  g2: 'mixed'        as GroupCohesion,
+  g3: 'medium'       as FitnessLevel,
+  g4: 'social'       as DrinkingCulture,
+  g5: 'team_players' as GroupDynamic,
+  g6: ['action', 'nightlife'],
+};
+
+function fillDefaults(a: WizardAnswers) {
+  return {
+    h1: a.h1 ?? DEFAULTS.h1,
+    h2: a.h2 ?? DEFAULTS.h2,
+    h3: a.h3 ?? DEFAULTS.h3,
+    h4: a.h4 ?? DEFAULTS.h4,
+    h5: a.h5 ?? DEFAULTS.h5,
+    h6: a.h6 ?? DEFAULTS.h6,
+    g1: a.g1 ?? DEFAULTS.g1,
+    g2: a.g2 ?? DEFAULTS.g2,
+    g3: a.g3 ?? DEFAULTS.g3,
+    g4: a.g4 ?? DEFAULTS.g4,
+    g5: a.g5 ?? DEFAULTS.g5,
+    g6: a.g6.length > 0 ? a.g6 : DEFAULTS.g6,
+  };
+}
+
+// --- Display name maps ---
+
+const ACTIVITY_NAMES: Record<string, string> = {
+  'Laser Tag Session':             'Laser Tag',
+  'Bowling + Drinks':              'Bowling',
+  'Bouldering / Indoor Climbing':  'Indoor Climbing',
+  'Blacklight Mini Golf':          'Mini Golf',
+  'Bubble Football':               'Bubble Football',
+  'Paintball / Airsoft':           'Paintball',
+  'Table Football Tournament':     'Table Football',
+  'Billiards + Table Service':     'Billiards',
+  'Harbor / River Cruise':         'Harbor Cruise',
+  'Boat Rental / Pedal Boat':      'Boat Rental',
+  'Outdoor Scavenger Hunt':        'Scavenger Hunt',
+  'Photo Challenge Walk + Print':  'Photo Challenge',
+  'Walking Tour':                  'City Walking Tour',
+  'Street Art / Underground Tour': 'Street Art Tour',
+  'Beach Day + Games':             'Beach Day',
+  'Musical / Theater Show':        'Theater Show',
+  'Comedy Show + Pre-Drinks':      'Comedy Show',
+  'Private Poker Night':           'Poker Night',
+  'Spa / Sauna Day Pass':          'Spa Day',
+  'Massage Add-On':                'Massage Session',
+  'Beer Tasting Flight':           'Beer Tasting',
+  'Whisky / Rum Tasting':          'Whisky Tasting',
+  'Gin Tasting + Botanicals':      'Gin Tasting',
+  'Cocktail Making Course':        'Cocktail Workshop',
+  'BBQ Grill & Chill':             'BBQ & Grill',
+};
+
+const DINING_NAMES: Record<string, string> = {
+  'Burger + Beer Combo':               'Casual Dinner & Drinks',
+  'Tapas / Shared Plates':             'Tapas Dinner',
+  'BBQ Ribs + Beer Tower':             'BBQ Dinner',
+  'Pizza Party + Craft Beer':          'Pizza & Craft Beer Dinner',
+  "Private Dining Room + Chef's Menu": 'Private Dining Experience',
+  'Beer Hall / Platter Night':         'Beer Hall Dinner',
+};
+
+const BAR_NAMES: Record<string, string> = {
+  'Bar Crawl':                       'Bar Crawl',
+  'Club Entry + Reserved Area':      'Club Night',
+  'Live Music Bar + Reserved Table': 'Live Music Bar',
+  'Karaoke Night':                   'Karaoke Night',
+  'Pub Quiz Night':                  'Pub Quiz Night',
+};
+
+function activityName(name: string): string {
+  return ACTIVITY_NAMES[name] ?? name;
+}
+function diningName(name: string): string {
+  return DINING_NAMES[name] ?? name;
+}
+function barName(name: string): string {
+  return BAR_NAMES[name] ?? 'Bar Night with Drinks';
+}
+
+// --- Tier config ---
+
+const TIER_PRICE: Record<string, number> = {
+  essential: 99_00,
+  classic:  149_00,
+  grand:    199_00,
+};
+
+const TIER_META = {
+  essential: {
+    rating: 4.5, review_count: 89,
+    description: 'The perfect starter package — one highlight activity, great dinner, and drinks included.',
+  },
+  classic: {
+    rating: 4.8, review_count: 127,
+    description: 'The ideal balance of activities, dining, and nightlife for an unforgettable celebration.',
+  },
+  grand: {
+    rating: 4.9, review_count: 42,
+    description: 'The ultimate premium experience with three activities, fine dining, and exclusive nightlife.',
+  },
+};
+
+// --- Main export ---
+
+export function assemblePackages(answers: WizardAnswers, citySlug: string): AssembledPackage[] {
+  const full = fillDefaults(answers);
+  const scored = scoreActivities(full);
+
+  // Split by category
+  const activities = scored
+    .filter(a => !['dining', 'nightlife'].includes(a.category))
+    .map(a => activityName(a.name));
+
+  const diningSlot = scored.find(a => a.category === 'dining');
+  const barSlot    = scored.find(a => a.category === 'nightlife');
+
+  const topDining = diningSlot ? diningName(diningSlot.name) : 'Restaurant Dinner';
+  const topBar    = barSlot    ? barName(barSlot.name)       : 'Bar Night with Drinks';
+
+  // Deduplicate activities, pad with last if fewer than 3
+  const uniqueActivities = [...new Set(activities)];
+  const act = (i: number) => uniqueActivities[i] ?? uniqueActivities[uniqueActivities.length - 1] ?? topDining;
+
+  const city = citySlug.charAt(0).toUpperCase() + citySlug.slice(1);
+
+  const tiers: Array<{ tier: 'essential' | 'classic' | 'grand'; features: string[]; bestMatch?: boolean }> = [
+    { tier: 'essential', features: [act(0), topDining, topBar] },
+    { tier: 'classic',   features: [act(0), act(1), topDining, topBar], bestMatch: true },
+    { tier: 'grand',     features: [act(0), act(1), act(2), topDining, topBar] },
+  ];
+
+  return tiers.map(({ tier, features, bestMatch }) => ({
+    id:   `${citySlug}-${tier}`,
+    name: `${city} ${tier.charAt(0).toUpperCase() + tier.slice(1)}`,
+    tier,
+    price_per_person_cents: TIER_PRICE[tier],
+    hero_image_url: getPackageImage(citySlug, tier),
+    ...TIER_META[tier],
+    features,
+    ...(bestMatch ? { bestMatch: true } : {}),
+  }));
+}

--- a/game-over-app/vercel.json
+++ b/game-over-app/vercel.json
@@ -1,0 +1,8 @@
+{
+  "framework": null,
+  "buildCommand": "npx expo export --platform web",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "game-over",
+  "private": true,
+  "scripts": {
+    "vercel-build": "cd game-over-app && npm install --legacy-peer-deps && npx expo export --platform web"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,4 @@
 {
-  "framework": null,
-  "buildCommand": "cd game-over-app && npm ci --legacy-peer-deps && npx expo export --platform web",
   "outputDirectory": "game-over-app/dist",
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "framework": null,
+  "buildCommand": "cd game-over-app && npm ci --legacy-peer-deps && npx expo export --platform web",
+  "outputDirectory": "game-over-app/dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replaced static dummy `FALLBACK_PACKAGES` in Wizard Step 4 with dynamically assembled packages driven by the H1–H6 / G1–G6 questionnaire answers
- New `src/utils/packageAssembly.ts` calls the existing `scoreActivities()` scoring matrix to pick the best-matched activities, dining slot, and bar/nightlife slot per tier
- Package S gets 1 activity + dining + bar (3 features), M gets 2 activities + dining + bar (4 features, bestMatch), L gets 3 activities + dining + bar (5 features)
- DB packages remain the primary source — assembled packages are the fallback when DB returns empty

## Changed Files

- `src/utils/packageAssembly.ts` — new utility (pure function, no side effects)
- `__tests__/unit/utils/packageAssembly.test.ts` — 10 unit tests (TDD)
- `__tests__/setup.ts` — 2 mocks added for packageImages + expo-asset
- `app/create-event/packages.tsx` — FALLBACK_PACKAGES removed, assemblePackages() wired in with full wizard state

## Test Plan

- [x] 45/45 unit tests pass (`npm test`)
- [x] TypeScript clean (`npm run typecheck`)
- [ ] Manual: navigate through full wizard (Steps 1–4) and verify package cards show personalized activity names matching the questionnaire answers
- [ ] Manual: verify "action" profile (H1=action, H3=competitive) shows Go-Karting / Laser Tag
- [ ] Manual: verify "relaxed" profile (H1=relaxed, H4=food) shows Cooking Class / Spa Day