### PR TITLE
fix: Tier 3 UX/Design fixes — dark theme, color unification, UX polish

### DIFF
--- a/game-over-app/CLAUDE.md
+++ b/game-over-app/CLAUDE.md
@@ -298,7 +298,7 @@ const DARK_THEME = {
   surface: '#1E2329',
   surfaceCard: '#23272F',
   deepNavy: '#2D3748',
-  primary: '#258CF4',
+  primary: '#5A7EB0',           // unified muted navy — replaces old #258CF4
   glassCard: 'rgba(45, 55, 72, 0.6)',
   textPrimary: '#FFFFFF',
   textSecondary: '#D1D5DB',
@@ -306,7 +306,7 @@ const DARK_THEME = {
 };
 ```
 
-**Active State Color:** All active elements (bottom nav, FAB, filter tabs) use `#5A7EB0`
+**Primary Color:** `#5A7EB0` (muted navy) — used for all active elements, buttons, icons, highlights. Old value `#258CF4` is deprecated; do not use it.
 
 **IMPORTANT:** Never use `useColorScheme()` or respect system color scheme settings. The app must always render in dark mode.
 

--- a/game-over-app/GO_LIVE_CHECKLIST.md
+++ b/game-over-app/GO_LIVE_CHECKLIST.md
@@ -352,6 +352,71 @@ SendGrid free trial ended July 7, 2025. The `/v3/mail/send` API endpoint is bloc
 
 ---
 
+## Migrations & Edge Functions
+
+### Apply Pending DB Migrations
+**Status:** 🔴 Required — 8 untracked migrations must be applied to production before go-live
+
+The following migrations exist locally but have NOT been pushed to the production Supabase project yet:
+
+```bash
+# Apply all pending migrations:
+npx supabase db push --project-ref stdbvehmjpmqbjyiodqg
+```
+
+- [ ] `20260315000000_invite_codes_guest_fields.sql` — guest name/phone fields on invite codes
+- [ ] `20260316000000_invite_preview_rpc.sql` — RPC function for invite preview without auth
+- [ ] `20260316000001_event_participants_guest_insert.sql` — RLS policy for guest participant inserts
+- [ ] `20260316000002_increment_invite_use_count.sql` — atomic use_count increment function
+- [ ] `20260317000000_profiles_add_phone.sql` — phone number field on profiles
+- [ ] `20260317000001_polls_allow_participants_insert.sql` — RLS policy for poll votes
+- [ ] `20260321000000_performance_indexes.sql` — 5 query indexes (events, bookings, notifications)
+- [ ] `20260321000001_bookings_integrity_constraints.sql` — UNIQUE on Stripe PI, CHECK constraints on amounts
+- [ ] `20260321000002_fix_cron_auth.sql` — updates cron jobs to use CRON_SECRET instead of service role key
+
+**Note:** Migration `20260321000001` includes a duplicate-data safety check — it will log a WARNING instead of failing if duplicate Stripe Payment Intent IDs already exist in production.
+
+---
+
+### Deploy Updated Edge Functions
+**Status:** 🔴 Required — 4 functions updated since last deploy
+
+The following edge functions have been modified and must be redeployed:
+
+```bash
+npx supabase functions deploy create-payment-intent --project-ref stdbvehmjpmqbjyiodqg
+npx supabase functions deploy send-guest-invitations --project-ref stdbvehmjpmqbjyiodqg
+npx supabase functions deploy send-final-briefing --project-ref stdbvehmjpmqbjyiodqg
+npx supabase functions deploy process-payment-reminders --project-ref stdbvehmjpmqbjyiodqg
+```
+
+- [ ] `create-payment-intent` — deposit percentage corrected (30% → 25%), added `deposit_paid_at` guard for remaining-balance payments
+- [ ] `send-guest-invitations` — refactored to use shared `_shared/twilio.ts` helper
+- [ ] `send-final-briefing` — refactored to use shared `_shared/twilio.ts` helper; WhatsApp→SMS fallback
+- [ ] `process-payment-reminders` — auto-cancellation rollback fix (cancellation failure now counted as error)
+
+---
+
+### Set Required Supabase Secrets
+**Status:** 🔴 Required — several secrets must be set before edge functions work in production
+
+```bash
+# Generate a strong random secret for cron authentication:
+openssl rand -hex 32
+
+npx supabase secrets set CRON_SECRET=<generated-value> --project-ref stdbvehmjpmqbjyiodqg
+npx supabase secrets set STRIPE_WEBHOOK_SECRET=<from-stripe-dashboard> --project-ref stdbvehmjpmqbjyiodqg
+npx supabase secrets set APP_BASE_URL=https://game-over.app --project-ref stdbvehmjpmqbjyiodqg
+```
+
+- [ ] `CRON_SECRET` — **NEW: required** by `process-payment-reminders` and `send-final-briefing`. Without it, both functions return 503/401 and no payment reminders or final briefings are ever sent.
+- [ ] Store the same `CRON_SECRET` value in Supabase **Vault** (Dashboard → Vault → New Secret, name: `CRON_SECRET`) — this is what the pg_cron jobs read.
+- [ ] `STRIPE_WEBHOOK_SECRET` — required by `stripe-webhook`. Get it from Stripe Dashboard → Webhooks → your endpoint → "Signing secret".
+- [ ] `APP_BASE_URL` — used by `send-guest-invitations` for invite links. Defaults to `https://game-over.app` if not set, but explicit is better.
+- [ ] Verify existing secrets are still set: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `TWILIO_SMS_FROM`, `SENDGRID_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
+
+---
+
 ## Backend & Infrastructure
 
 ### Supabase Configuration
@@ -441,12 +506,25 @@ SendGrid free trial ended July 7, 2025. The `/v3/mail/send` API endpoint is bloc
 
 **Status:** ⏸️ Pending
 
+### General
 - [ ] Monitor crash reports
 - [ ] Monitor user feedback and reviews
 - [ ] Set up customer support system
 - [ ] Plan feature updates and bug fix releases
 - [ ] Monitor Stripe dashboard for payment issues
 - [ ] Monitor Supabase usage and costs
+
+### Payment Reminders & Auto-Cancellation (monitor closely first 2 weeks)
+- [ ] **Verify cron jobs are running** — Supabase Dashboard → Database → Cron Jobs → check `process-payment-reminders` and `send-final-briefing-daily` have a recent `last_run`
+- [ ] **Check `payment_reminders` table** for rows being created when bookings approach their milestone dates (21/18/16/14 days before event)
+- [ ] **Confirm auto-cancellation is working** — at 14-day milestone, unpaid bookings should have `events.status = 'cancelled'`. Verify at least one case manually.
+- [ ] **Monitor for `[CRITICAL]` log entries** in `process-payment-reminders` function logs (Supabase → Edge Functions → Logs). A `[CRITICAL]` entry means a cancellation failed and requires manual investigation.
+- [ ] **Verify push + email reminders** are reaching organizers — check that `payment_reminders.push_sent` and `email_sent` columns are `true` for recent rows.
+
+### Final Briefing (monitor after first event hits 3-day mark)
+- [ ] Verify WhatsApp messages delivered to guests 3 days before the first event
+- [ ] Check `planning_checklist.final_briefing = true` is set on events after briefings are sent (prevents re-sending)
+- [ ] Confirm SMS fallback triggers correctly for guests not on WhatsApp (Twilio error codes 63016/63007)
 
 ---
 

--- a/game-over-app/app.config.ts
+++ b/game-over-app/app.config.ts
@@ -14,7 +14,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     resizeMode: 'contain',
     backgroundColor: '#15181D', // Match DARK_THEME.background
   },
-  assetBundlePatterns: ['**/*'],
+  // Bundle image assets only — excludes assets/store/*.md and assets/store/*.txt (app store copy)
+  assetBundlePatterns: ['**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif', '**/*.svg', '**/*.webp'],
   ios: {
     supportsTablet: true,
     bundleIdentifier: 'app.gameover.ios',

--- a/game-over-app/app/(tabs)/_layout.tsx
+++ b/game-over-app/app/(tabs)/_layout.tsx
@@ -146,19 +146,7 @@ function CustomTabBar({ state, descriptors, navigation }: any) {
   const isChannelDetailScreen = currentRoute?.name === 'chat' &&
     innerRoute?.name?.includes('[channelId]');
 
-  // Recursively check if any nested route has an eventId param
-  const routeHasEventId = (route: any): boolean => {
-    if (!route) return false;
-    if ((route.params as any)?.eventId) return true;
-    if (route.state?.routes) return route.state.routes.some(routeHasEventId);
-    return false;
-  };
-
-  // Hide tab bar when chat or budget opened from Event Summary (eventId param present)
-  const isChatFromEventSummary = currentRoute?.name === 'chat' && routeHasEventId(currentRoute);
-  const isBudgetFromEventSummary = currentRoute?.name === 'budget' && routeHasEventId(currentRoute);
-
-  if (tabBarHidden || isChannelDetailScreen || isChatFromEventSummary || isBudgetFromEventSummary) {
+  if (tabBarHidden || isChannelDetailScreen) {
     return null;
   }
 

--- a/game-over-app/app/(tabs)/_layout.tsx
+++ b/game-over-app/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Tabs, useRouter } from 'expo-router';
+import { useEffect } from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Alert, View, StyleSheet, Pressable, Platform, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -219,6 +220,11 @@ function CustomTabBar({ state, descriptors, navigation }: any) {
 }
 
 export default function TabsLayout() {
+  // Safety reset: ensure tab bar is never stuck hidden after hard navigation
+  useEffect(() => {
+    useTabBarStore.getState().setHidden(false);
+  }, []);
+
   return (
     <ErrorBoundary fallbackTitle="Tab Error">
     <Tabs

--- a/game-over-app/app/(tabs)/budget/index.tsx
+++ b/game-over-app/app/(tabs)/budget/index.tsx
@@ -147,20 +147,27 @@ export default function BudgetDashboardScreen() {
   const setTabBarHidden = useTabBarStore((s) => s.setHidden);
 
   // Remind-all channel picker modal
-  const [remindModalVisible, setRemindModalVisible] = useState(false);
-  const [remindSendStatus, setRemindSendStatus] = useState<'idle' | 'sending' | 'done'>('idle');
-  const [remindActiveChannel, setRemindActiveChannel] = useState<'email' | 'sms' | 'whatsapp' | null>(null);
-  const [remindResults, setRemindResults] = useState<Array<{ status: string; recipient: string; error?: string }>>([]);
+  const [remindModal, setRemindModal] = useState<{
+    visible: boolean;
+    sendStatus: 'idle' | 'sending' | 'done';
+    activeChannel: 'email' | 'sms' | 'whatsapp' | null;
+    results: Array<{ status: string; recipient: string; error?: string }>;
+  }>({ visible: false, sendStatus: 'idle', activeChannel: null, results: [] });
 
   // Expense modal
-  const [expenseModalVisible, setExpenseModalVisible] = useState(false);
-  const [expenseCategoryKey, setExpenseCategoryKey] = useState<string | null>(null);
-  const [expenseViewMode, setExpenseViewMode] = useState<'list' | 'form'>('form');
-  const [expenseDescription, setExpenseDescription] = useState('');
-  const [expenseAmount, setExpenseAmount] = useState('');
-  const [expensePaidBy, setExpensePaidBy] = useState<'you' | 'other'>('you');
-  const [expensePaidByPerson, setExpensePaidByPerson] = useState<string | null>(null);
-  const [expenseContributors, setExpenseContributors] = useState<string[]>([]);
+  const [expenseModal, setExpenseModal] = useState<{
+    visible: boolean;
+    categoryKey: string | null;
+    viewMode: 'list' | 'form';
+    description: string;
+    amount: string;
+    paidBy: 'you' | 'other';
+    paidByPerson: string | null;
+    contributors: string[];
+    editingIndex: number | null;
+    payerDropdownOpen: boolean;
+  }>({ visible: false, categoryKey: null, viewMode: 'form', description: '', amount: '', paidBy: 'you', paidByPerson: null, contributors: [], editingIndex: null, payerDropdownOpen: false });
+
   const [addedExpenses, setAddedExpenses] = useState<Array<{
     categoryKey: string; description: string; amount: string;
     paidBy: 'you' | 'other'; paidByPerson?: string | null; contributors: string[];
@@ -168,22 +175,23 @@ export default function BudgetDashboardScreen() {
 
   // Custom categories (user-created)
   const [customCategories, setCustomCategories] = useState<ExpenseCategory[]>([]);
-  const [customCategoryModalVisible, setCustomCategoryModalVisible] = useState(false);
-  const [customCategoryLabel, setCustomCategoryLabel] = useState('');
+  const [customCatModal, setCustomCatModal] = useState<{
+    visible: boolean;
+    label: string;
+  }>({ visible: false, label: '' });
 
   // Refund modal
-  const [refundModalVisible, setRefundModalVisible] = useState(false);
-  const [refundTemplateKey, setRefundTemplateKey] = useState<string | null>(null);
-  const [refundDescription, setRefundDescription] = useState('');
-  const [refundAmount, setRefundAmount] = useState('');
+  const [refundModal, setRefundModal] = useState<{
+    visible: boolean;
+    templateKey: string | null;
+    description: string;
+    amount: string;
+  }>({ visible: false, templateKey: null, description: '', amount: '' });
+
   const [addedRefunds, setAddedRefunds] = useState<Array<{ description: string; amount: string; status: 'processing' | 'received'; icon?: string; color?: string; bg?: string; }>>([]);
 
   // Ref always holds latest contributors — avoids declaration-order TDZ issue with useCallback
   const allContributorsRef = useRef<Array<{ id: string; name: string; userId?: string | null; role?: string }>>([]);
-
-  // Track which expense index is being edited (null = creating new)
-  const [editingExpenseIndex, setEditingExpenseIndex] = useState<number | null>(null);
-  const [payerDropdownOpen, setPayerDropdownOpen] = useState(false);
 
   // Drag-to-dismiss for budget modals (matches destination.tsx pattern)
   const expenseSheetY = useRef(new Animated.Value(0)).current;
@@ -205,75 +213,77 @@ export default function BudgetDashboardScreen() {
       },
     });
 
-  const expenseSheetPan = useRef(makeModalPan(expenseSheetY, () => setExpenseModalVisible(false))).current;
-  const refundSheetPan = useRef(makeModalPan(refundSheetY, () => setRefundModalVisible(false))).current;
-  const customCatSheetPan = useRef(makeModalPan(customCatSheetY, () => setCustomCategoryModalVisible(false))).current;
+  const expenseSheetPan = useRef(makeModalPan(expenseSheetY, () => setExpenseModal(prev => ({ ...prev, visible: false })))).current;
+  const refundSheetPan = useRef(makeModalPan(refundSheetY, () => setRefundModal(prev => ({ ...prev, visible: false })))).current;
+  const customCatSheetPan = useRef(makeModalPan(customCatSheetY, () => setCustomCatModal(prev => ({ ...prev, visible: false })))).current;
 
   const openExpenseModal = useCallback((categoryKey: string) => {
-    setEditingExpenseIndex(null);
-    setExpenseCategoryKey(categoryKey);
     const existing = addedExpenses.filter(e => e.categoryKey === categoryKey);
-    setExpenseViewMode(existing.length > 0 ? 'list' : 'form');
-    setExpenseDescription('');
-    setExpenseAmount('');
-    setExpensePaidBy('you');
-    setExpensePaidByPerson(null);
-    setExpenseContributors([]);
-    setExpenseModalVisible(true);
+    setExpenseModal(prev => ({
+      ...prev,
+      editingIndex: null,
+      categoryKey,
+      viewMode: existing.length > 0 ? 'list' : 'form',
+      description: '',
+      amount: '',
+      paidBy: 'you',
+      paidByPerson: null,
+      contributors: [],
+      visible: true,
+    }));
   }, [addedExpenses]);
 
   const openEditExpense = useCallback((globalIdx: number) => {
     const exp = addedExpenses[globalIdx];
     if (!exp) return;
-    setEditingExpenseIndex(globalIdx);
-    setExpenseCategoryKey(exp.categoryKey);
-    setExpenseDescription(exp.description);
-    setExpenseAmount(exp.amount);
-    setExpensePaidBy(exp.paidBy);
-    setExpensePaidByPerson(exp.paidByPerson || null);
-    setExpenseContributors(exp.contributors);
-    setExpenseViewMode('form');
-    setExpenseModalVisible(true);
+    setExpenseModal(prev => ({
+      ...prev,
+      editingIndex: globalIdx,
+      categoryKey: exp.categoryKey,
+      description: exp.description,
+      amount: exp.amount,
+      paidBy: exp.paidBy,
+      paidByPerson: exp.paidByPerson || null,
+      contributors: exp.contributors,
+      viewMode: 'form',
+      visible: true,
+    }));
   }, [addedExpenses]);
 
   const submitExpense = useCallback(() => {
-    if (!expenseDescription.trim() || !expenseAmount.trim() || !expenseCategoryKey) return;
+    if (!expenseModal.description.trim() || !expenseModal.amount.trim() || !expenseModal.categoryKey) return;
     const newExpense = {
-      categoryKey: expenseCategoryKey,
-      description: expenseDescription.trim(),
-      amount: expenseAmount.trim(),
-      paidBy: expensePaidBy,
-      paidByPerson: expensePaidBy === 'other' ? expensePaidByPerson : null,
-      contributors: expenseContributors,
+      categoryKey: expenseModal.categoryKey,
+      description: expenseModal.description.trim(),
+      amount: expenseModal.amount.trim(),
+      paidBy: expenseModal.paidBy,
+      paidByPerson: expenseModal.paidBy === 'other' ? expenseModal.paidByPerson : null,
+      contributors: expenseModal.contributors,
     };
     setAddedExpenses(prev => {
-      const updated = editingExpenseIndex !== null
-        ? prev.map((e, i) => i === editingExpenseIndex ? newExpense : e)
+      const updated = expenseModal.editingIndex !== null
+        ? prev.map((e, i) => i === expenseModal.editingIndex ? newExpense : e)
         : [...prev, newExpense];
       if (selectedEventId) {
         AsyncStorage.setItem(`gameover:expenses:${selectedEventId}`, JSON.stringify(updated));
       }
       return updated;
     });
-    setEditingExpenseIndex(null);
-    setExpenseModalVisible(false);
-  }, [expenseDescription, expenseAmount, expenseCategoryKey, expensePaidBy, expensePaidByPerson, expenseContributors, selectedEventId, editingExpenseIndex]);
+    setExpenseModal(prev => ({ ...prev, editingIndex: null, visible: false }));
+  }, [expenseModal, selectedEventId]);
 
   const openRefundModal = useCallback(() => {
-    setRefundTemplateKey(null);
-    setRefundDescription('');
-    setRefundAmount('');
-    setRefundModalVisible(true);
+    setRefundModal({ visible: true, templateKey: null, description: '', amount: '' });
   }, []);
 
   const submitRefund = useCallback(() => {
-    if (!refundDescription.trim() || !refundAmount.trim()) return;
-    const tmpl = REFUND_TEMPLATES.find(t => t.key === refundTemplateKey);
+    if (!refundModal.description.trim() || !refundModal.amount.trim()) return;
+    const tmpl = REFUND_TEMPLATES.find(t => t.key === refundModal.templateKey);
     setAddedRefunds(prev => {
       const customColor = CUSTOM_COLORS[prev.length % CUSTOM_COLORS.length];
       const updated = [{
-        description: refundDescription.trim(),
-        amount: refundAmount.trim(),
+        description: refundModal.description.trim(),
+        amount: refundModal.amount.trim(),
         status: 'processing' as const,
         icon: tmpl?.icon ?? 'receipt-outline',
         color: tmpl?.color ?? customColor.color,
@@ -284,8 +294,8 @@ export default function BudgetDashboardScreen() {
       }
       return updated;
     });
-    setRefundModalVisible(false);
-  }, [refundDescription, refundAmount, refundTemplateKey, selectedEventId]);
+    setRefundModal(prev => ({ ...prev, visible: false }));
+  }, [refundModal, selectedEventId]);
 
   // Hide tab bar when opened from Event Summary (eventIdParam present).
   // Also refetch participants on focus so payment status reflects "I've Paid" from Notifications screen.
@@ -497,23 +507,19 @@ export default function BudgetDashboardScreen() {
     if (effectiveEventId) {
       router.push(`/event/${effectiveEventId}/share`);
     } else {
-      Alert.alert('No Event Selected', 'Select an event first to send invitations.');
+      Alert.alert(t.budget.noEventSelected, t.budget.noEventSelectedMsg);
     }
   }, [selectedEventId, eventIdParam, router]);
 
   // Remind All — opens channel picker modal (same UX as Manage Invitations)
   const handleRemindAll = useCallback(() => {
-    setRemindSendStatus('idle');
-    setRemindResults([]);
-    setRemindActiveChannel(null);
-    setRemindModalVisible(true);
+    setRemindModal({ visible: true, sendStatus: 'idle', activeChannel: null, results: [] });
   }, []);
 
   // Send reminder via chosen channel using the guest-invitations edge function
   const handleRemindViaChannel = useCallback(async (channel: 'email' | 'sms' | 'whatsapp') => {
     if (!selectedEventId) return;
-    setRemindActiveChannel(channel);
-    setRemindSendStatus('sending');
+    setRemindModal(prev => ({ ...prev, activeChannel: channel, sendStatus: 'sending' }));
     try {
       await supabase.auth.refreshSession().catch(() => {});
       const guestDetailsMap = await loadGuestDetails(selectedEventId);
@@ -533,15 +539,14 @@ export default function BudgetDashboardScreen() {
           const body = await (error as any).context?.json?.();
           if (body?.error) detail = body.error;
         } catch {}
-        Alert.alert('Send failed', detail);
-        setRemindSendStatus('idle');
+        Alert.alert(t.budget.sendFailed, detail);
+        setRemindModal(prev => ({ ...prev, sendStatus: 'idle' }));
         return;
       }
-      setRemindResults(data?.results ?? []);
-      setRemindSendStatus('done');
+      setRemindModal(prev => ({ ...prev, results: data?.results ?? [], sendStatus: 'done' }));
     } catch {
-      Alert.alert('Error', 'Could not send reminders. Try again.');
-      setRemindSendStatus('idle');
+      Alert.alert(t.common.error, t.budget.errorSendingReminders);
+      setRemindModal(prev => ({ ...prev, sendStatus: 'idle' }));
     }
   }, [selectedEventId]);
 
@@ -1322,12 +1327,12 @@ export default function BudgetDashboardScreen() {
                           disabled={markingPaidUserId === user?.id}
                           onPress={() => {
                             Alert.alert(
-                              'Confirm Payment',
-                              'Have you transferred your share to the organizer?',
+                              t.budget.confirmPayment,
+                              t.budget.confirmPaymentMsg,
                               [
-                                { text: 'Not yet', style: 'cancel' },
+                                { text: t.budget.notYet, style: 'cancel' },
                                 {
-                                  text: "Yes, I've Paid",
+                                  text: t.budget.yesPaid,
                                   onPress: async () => {
                                     if (!selectedEventId || !user?.id) return;
                                     setMarkingPaidUserId(user.id);
@@ -1339,9 +1344,9 @@ export default function BudgetDashboardScreen() {
                                         .eq('user_id', user.id);
                                       queryClient.invalidateQueries({ queryKey: participantKeys.byEvent(selectedEventId) });
                                       queryClient.invalidateQueries({ queryKey: ['guestParticipations', user.id] });
-                                      Alert.alert('Thank you!', 'Your payment has been confirmed. The organizer will be notified.');
+                                      Alert.alert(t.budget.thankYou, t.budget.paymentConfirmedMsg);
                                     } catch {
-                                      Alert.alert('Error', 'Could not update status. Please try again.');
+                                      Alert.alert(t.common.error, t.budget.errorUpdatingStatus);
                                     } finally {
                                       setMarkingPaidUserId(null);
                                     }
@@ -1414,7 +1419,7 @@ export default function BudgetDashboardScreen() {
                   {(t.budget as any).expenseBreakdown}
                 </Text>
                 <Pressable
-                  onPress={() => { setExpenseCategoryKey(null); setExpenseViewMode('form'); setExpenseModalVisible(true); }}
+                  onPress={() => { setExpenseModal(prev => ({ ...prev, categoryKey: null, viewMode: 'form', visible: true })); }}
                   style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
                 >
                   <Ionicons name="add-circle-outline" size={16} color={DARK_THEME.primary} />
@@ -1497,8 +1502,7 @@ export default function BudgetDashboardScreen() {
                 <Pressable
                   style={styles.addCustomCategoryRow}
                   onPress={() => {
-                    setCustomCategoryLabel('');
-                    setCustomCategoryModalVisible(true);
+                    setCustomCatModal({ visible: true, label: '' });
                   }}
                 >
                   <View style={[styles.refundIcon, { backgroundColor: 'rgba(255,255,255,0.05)' }]}>
@@ -1568,21 +1572,21 @@ export default function BudgetDashboardScreen() {
       </Animated.View>
 
       {/* ─── Expense Popup — inline, no Modal (matches destination.tsx drag pattern) ─── */}
-      {expenseModalVisible && (
+      {expenseModal.visible && (
         <View style={styles.popupOverlay} pointerEvents="box-none">
-          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setExpenseModalVisible(false)} />
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setExpenseModal(prev => ({ ...prev, visible: false }))} />
           <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1, justifyContent: 'flex-end' }}>
             <Animated.View style={[styles.modalSheet, { transform: [{ translateY: expenseSheetY }] }]}>
               <View {...expenseSheetPan.panHandlers} style={styles.modalDragHandleArea}>
                 <View style={styles.modalDragHandle} />
               </View>
               <ScrollView bounces={false} showsVerticalScrollIndicator={false}>
-                {!expenseCategoryKey ? (
+                {!expenseModal.categoryKey ? (
                   /* ── Mode 1: Category picker ── */
                   <>
                     <XStack justifyContent="space-between" alignItems="center" marginBottom={20}>
                       <Text style={styles.modalTitle}>Select Category</Text>
-                      <Pressable onPress={() => setExpenseModalVisible(false)} hitSlop={10}>
+                      <Pressable onPress={() => setExpenseModal(prev => ({ ...prev, visible: false }))} hitSlop={10}>
                         <Ionicons name="close" size={22} color={DARK_THEME.textSecondary} />
                       </Pressable>
                     </XStack>
@@ -1592,13 +1596,16 @@ export default function BudgetDashboardScreen() {
                         style={styles.templateRow}
                         onPress={() => {
                           const existing = addedExpenses.filter(e => e.categoryKey === cat.key);
-                          setExpenseCategoryKey(cat.key);
-                          setExpenseViewMode(existing.length > 0 ? 'list' : 'form');
-                          setExpenseDescription('');
-                          setExpenseAmount('');
-                          setExpensePaidBy('you');
-                          setExpensePaidByPerson(null);
-                          setExpenseContributors([]);
+                          setExpenseModal(prev => ({
+                            ...prev,
+                            categoryKey: cat.key,
+                            viewMode: existing.length > 0 ? 'list' : 'form',
+                            description: '',
+                            amount: '',
+                            paidBy: 'you',
+                            paidByPerson: null,
+                            contributors: [],
+                          }));
                         }}
                       >
                         <View style={[styles.refundIcon, { backgroundColor: cat.bg }]}>
@@ -1614,9 +1621,8 @@ export default function BudgetDashboardScreen() {
                     <Pressable
                       style={styles.templateRow}
                       onPress={() => {
-                        setExpenseModalVisible(false);
-                        setCustomCategoryLabel('');
-                        setCustomCategoryModalVisible(true);
+                        setExpenseModal(prev => ({ ...prev, visible: false }));
+                        setCustomCatModal({ visible: true, label: '' });
                       }}
                     >
                       <View style={[styles.refundIcon, { backgroundColor: 'rgba(255,255,255,0.05)' }]}>
@@ -1626,11 +1632,11 @@ export default function BudgetDashboardScreen() {
                       <Ionicons name="chevron-forward" size={16} color={DARK_THEME.textTertiary} />
                     </Pressable>
                   </>
-                ) : expenseViewMode === 'list' ? (
+                ) : expenseModal.viewMode === 'list' ? (
                   /* ── Mode 2: Existing expenses list ── */
                   (() => {
-                    const expCat = allExpenseCategories.find(c => c.key === expenseCategoryKey)!;
-                    const catExpenses = [...addedExpenses.filter(e => e.categoryKey === expenseCategoryKey)].reverse();
+                    const expCat = allExpenseCategories.find(c => c.key === expenseModal.categoryKey)!;
+                    const catExpenses = [...addedExpenses.filter(e => e.categoryKey === expenseModal.categoryKey)].reverse();
                     return (
                       <>
                         <XStack alignItems="center" gap={12} marginBottom={20}>
@@ -1643,7 +1649,7 @@ export default function BudgetDashboardScreen() {
                             </Text>
                             <Text style={styles.modalNote}>{catExpenses.length} expense{catExpenses.length !== 1 ? 's' : ''}</Text>
                           </YStack>
-                          <Pressable onPress={() => setExpenseModalVisible(false)} hitSlop={10}>
+                          <Pressable onPress={() => setExpenseModal(prev => ({ ...prev, visible: false }))} hitSlop={10}>
                             <Ionicons name="close" size={22} color={DARK_THEME.textSecondary} />
                           </Pressable>
                         </XStack>
@@ -1654,13 +1660,16 @@ export default function BudgetDashboardScreen() {
                               key={i}
                               style={[styles.expenseListRow, i < catExpenses.length - 1 && styles.contributionRowBorder]}
                               onPress={() => {
-                                setEditingExpenseIndex(globalIdx);
-                                setExpenseDescription(exp.description);
-                                setExpenseAmount(exp.amount);
-                                setExpensePaidBy(exp.paidBy);
-                                setExpensePaidByPerson(exp.paidByPerson || null);
-                                setExpenseContributors(exp.contributors);
-                                setExpenseViewMode('form');
+                                setExpenseModal(prev => ({
+                                  ...prev,
+                                  editingIndex: globalIdx,
+                                  description: exp.description,
+                                  amount: exp.amount,
+                                  paidBy: exp.paidBy,
+                                  paidByPerson: exp.paidByPerson || null,
+                                  contributors: exp.contributors,
+                                  viewMode: 'form',
+                                }));
                               }}
                             >
                               <YStack flex={1}>
@@ -1678,18 +1687,21 @@ export default function BudgetDashboardScreen() {
                         <Pressable
                           style={[styles.submitButton, { marginTop: 16, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6 }]}
                           onPress={() => {
-                            setExpenseViewMode('form');
-                            setExpenseDescription('');
-                            setExpenseAmount('');
-                            setExpensePaidBy('you');
-                            setExpensePaidByPerson(null);
-                            setExpenseContributors([]);
+                            setExpenseModal(prev => ({
+                              ...prev,
+                              viewMode: 'form',
+                              description: '',
+                              amount: '',
+                              paidBy: 'you',
+                              paidByPerson: null,
+                              contributors: [],
+                            }));
                           }}
                         >
                           <Ionicons name="add" size={18} color="#FFFFFF" />
                           <Text style={styles.submitButtonText}>Add Another</Text>
                         </Pressable>
-                        <Pressable style={{ marginTop: 12, alignItems: 'center' }} onPress={() => setExpenseCategoryKey(null)}>
+                        <Pressable style={{ marginTop: 12, alignItems: 'center' }} onPress={() => setExpenseModal(prev => ({ ...prev, categoryKey: null }))}>
                           <Text style={{ color: DARK_THEME.textSecondary, fontSize: 13 }}>← Change category</Text>
                         </Pressable>
                       </>
@@ -1698,8 +1710,8 @@ export default function BudgetDashboardScreen() {
                 ) : (
                   /* ── Mode 3: Expense form with contributor selection ── */
                   (() => {
-                    const expCat = allExpenseCategories.find(c => c.key === expenseCategoryKey)!;
-                    const hasExisting = addedExpenses.filter(e => e.categoryKey === expenseCategoryKey).length > 0;
+                    const expCat = allExpenseCategories.find(c => c.key === expenseModal.categoryKey)!;
+                    const hasExisting = addedExpenses.filter(e => e.categoryKey === expenseModal.categoryKey).length > 0;
                     return (
                       <>
                         <XStack alignItems="center" gap={12} marginBottom={20}>
@@ -1714,7 +1726,7 @@ export default function BudgetDashboardScreen() {
                               <Text style={styles.modalNote}>{(t.budget as any).expensePackageNote || 'Extra costs beyond package'}</Text>
                             )}
                           </YStack>
-                          <Pressable onPress={() => setExpenseModalVisible(false)} hitSlop={10}>
+                          <Pressable onPress={() => setExpenseModal(prev => ({ ...prev, visible: false }))} hitSlop={10}>
                             <Ionicons name="close" size={22} color={DARK_THEME.textSecondary} />
                           </Pressable>
                         </XStack>
@@ -1723,8 +1735,8 @@ export default function BudgetDashboardScreen() {
                           style={styles.modalInput}
                           placeholder="e.g. Hotel booking, train tickets..."
                           placeholderTextColor={DARK_THEME.textTertiary}
-                          value={expenseDescription}
-                          onChangeText={setExpenseDescription}
+                          value={expenseModal.description}
+                          onChangeText={v => setExpenseModal(prev => ({ ...prev, description: v }))}
                           autoCapitalize="sentences"
                         />
                         <Text style={styles.inputLabel}>Amount (€)</Text>
@@ -1732,49 +1744,49 @@ export default function BudgetDashboardScreen() {
                           style={styles.modalInput}
                           placeholder="0.00"
                           placeholderTextColor={DARK_THEME.textTertiary}
-                          value={expenseAmount}
-                          onChangeText={setExpenseAmount}
+                          value={expenseModal.amount}
+                          onChangeText={v => setExpenseModal(prev => ({ ...prev, amount: v }))}
                           keyboardType="decimal-pad"
                         />
                         <Text style={styles.inputLabel}>Who paid?</Text>
-                        <XStack gap={10} style={{ marginBottom: expensePaidBy === 'other' ? 12 : 20 }}>
+                        <XStack gap={10} style={{ marginBottom: expenseModal.paidBy === 'other' ? 12 : 20 }}>
                           {(['you', 'other'] as const).map(opt => (
                             <Pressable
                               key={opt}
-                              style={[styles.paidByButton, expensePaidBy === opt && styles.paidByButtonActive]}
-                              onPress={() => { setExpensePaidBy(opt); if (opt !== 'other') setExpensePaidByPerson(null); }}
+                              style={[styles.paidByButton, expenseModal.paidBy === opt && styles.paidByButtonActive]}
+                              onPress={() => { setExpenseModal(prev => ({ ...prev, paidBy: opt, paidByPerson: opt !== 'other' ? null : prev.paidByPerson })); }}
                             >
-                              <Text style={[styles.paidByText, expensePaidBy === opt && styles.paidByTextActive]}>
+                              <Text style={[styles.paidByText, expenseModal.paidBy === opt && styles.paidByTextActive]}>
                                 {opt === 'you' ? 'You' : 'Someone else'}
                               </Text>
                             </Pressable>
                           ))}
                         </XStack>
                         {/* Person picker — dropdown button when "Someone else" is selected */}
-                        {expensePaidBy === 'other' && payerOptions.length > 0 && (
+                        {expenseModal.paidBy === 'other' && payerOptions.length > 0 && (
                           <View style={{ marginBottom: 16 }}>
                             {/* Dropdown trigger button */}
                             <Pressable
-                              style={[styles.dropdownButton, expensePaidByPerson && styles.dropdownButtonSelected]}
-                              onPress={() => setPayerDropdownOpen(o => !o)}
+                              style={[styles.dropdownButton, expenseModal.paidByPerson && styles.dropdownButtonSelected]}
+                              onPress={() => setExpenseModal(prev => ({ ...prev, payerDropdownOpen: !prev.payerDropdownOpen }))}
                             >
-                              <Text style={[styles.dropdownButtonText, expensePaidByPerson && { color: DARK_THEME.textPrimary }]}>
-                                {expensePaidByPerson
-                                  ? payerOptions.find(c => c.id === expensePaidByPerson)?.name ?? 'Select person'
+                              <Text style={[styles.dropdownButtonText, expenseModal.paidByPerson && { color: DARK_THEME.textPrimary }]}>
+                                {expenseModal.paidByPerson
+                                  ? payerOptions.find(c => c.id === expenseModal.paidByPerson)?.name ?? 'Select person'
                                   : 'Select person'}
                               </Text>
                               <Ionicons
-                                name={payerDropdownOpen ? 'chevron-up' : 'chevron-down'}
+                                name={expenseModal.payerDropdownOpen ? 'chevron-up' : 'chevron-down'}
                                 size={16}
                                 color={DARK_THEME.textTertiary}
                               />
                             </Pressable>
                             {/* Dropdown list — max 4 rows visible, inner scroll for rest */}
-                            {payerDropdownOpen && (
+                            {expenseModal.payerDropdownOpen && (
                               <View style={[styles.dropdownList, { maxHeight: 176 }]}>
                                 <ScrollView bounces={false} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
                                 {payerOptions.map((c, i) => {
-                                  const sel = expensePaidByPerson === c.id;
+                                  const sel = expenseModal.paidByPerson === c.id;
                                   return (
                                     <Pressable
                                       key={c.id}
@@ -1784,8 +1796,7 @@ export default function BudgetDashboardScreen() {
                                         i < payerOptions.length - 1 && styles.dropdownItemBorder,
                                       ]}
                                       onPress={() => {
-                                        setExpensePaidByPerson(sel ? null : c.id);
-                                        setPayerDropdownOpen(false);
+                                        setExpenseModal(prev => ({ ...prev, paidByPerson: sel ? null : c.id, payerDropdownOpen: false }));
                                       }}
                                     >
                                       <Text style={[styles.dropdownItemText, sel && { color: '#5A7EB0', fontWeight: '700' as const }]}>
@@ -1803,23 +1814,26 @@ export default function BudgetDashboardScreen() {
                         {/* Contributors — payer is always excluded to avoid duplication */}
                         {(() => {
                           // When "You" pays, exclude the current user's entry (not index 0 which is always the organizer)
-                          const payerExcludedId = expensePaidBy === 'you'
+                          const payerExcludedId = expenseModal.paidBy === 'you'
                             ? (allContributors.find(c => c.userId === user?.id)?.id ?? allContributors[0]?.id ?? null)
-                            : expensePaidByPerson;
+                            : expenseModal.paidByPerson;
                           const contributorOptions = allContributors.filter(c => c.id !== payerExcludedId);
                           if (contributorOptions.length === 0) return null;
                           return (
                             <>
                               <Text style={styles.inputLabel}>Who should contribute?</Text>
                               {contributorOptions.map(contributor => {
-                                const selected = expenseContributors.includes(contributor.id);
+                                const selected = expenseModal.contributors.includes(contributor.id);
                                 return (
                                   <Pressable
                                     key={contributor.id}
                                     style={[styles.contributorRow, selected && styles.contributorRowSelected]}
-                                    onPress={() => setExpenseContributors(prev =>
-                                      selected ? prev.filter(id => id !== contributor.id) : [...prev, contributor.id]
-                                    )}
+                                    onPress={() => setExpenseModal(prev => ({
+                                      ...prev,
+                                      contributors: selected
+                                        ? prev.contributors.filter(id => id !== contributor.id)
+                                        : [...prev.contributors, contributor.id],
+                                    }))}
                                   >
                                     <Text style={styles.contributorName}>{contributor.name}</Text>
                                     <View style={[styles.contributorCheck, selected && styles.contributorCheckSelected]}>
@@ -1832,21 +1846,21 @@ export default function BudgetDashboardScreen() {
                           );
                         })()}
                         <Pressable
-                          style={[styles.submitButton, { marginTop: 20 }, (!expenseDescription.trim() || !expenseAmount.trim()) && styles.submitButtonDisabled]}
+                          style={[styles.submitButton, { marginTop: 20 }, (!expenseModal.description.trim() || !expenseModal.amount.trim()) && styles.submitButtonDisabled]}
                           onPress={submitExpense}
-                          disabled={!expenseDescription.trim() || !expenseAmount.trim()}
+                          disabled={!expenseModal.description.trim() || !expenseModal.amount.trim()}
                         >
                           <Text style={styles.submitButtonText}>
-                            {editingExpenseIndex !== null ? 'Save Changes' : 'Add Expense'}
+                            {expenseModal.editingIndex !== null ? 'Save Changes' : 'Add Expense'}
                           </Text>
                         </Pressable>
                         <Pressable
                           style={{ marginTop: 12, alignItems: 'center' }}
                           onPress={() => {
                             if (hasExisting) {
-                              setExpenseViewMode('list');
+                              setExpenseModal(prev => ({ ...prev, viewMode: 'list' }));
                             } else {
-                              setExpenseCategoryKey(null);
+                              setExpenseModal(prev => ({ ...prev, categoryKey: null }));
                             }
                           }}
                         >
@@ -1865,9 +1879,9 @@ export default function BudgetDashboardScreen() {
       )}
 
       {/* ─── Refund Popup — inline, no Modal (matches destination.tsx drag pattern) ─── */}
-      {refundModalVisible && (
+      {refundModal.visible && (
         <View style={styles.popupOverlay} pointerEvents="box-none">
-          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setRefundModalVisible(false)} />
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setRefundModal(prev => ({ ...prev, visible: false }))} />
           <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1, justifyContent: 'flex-end' }}>
             <Animated.View style={[styles.modalSheet, { transform: [{ translateY: refundSheetY }] }]}>
               <View {...refundSheetPan.panHandlers} style={styles.modalDragHandleArea}>
@@ -1875,12 +1889,12 @@ export default function BudgetDashboardScreen() {
               </View>
               <XStack justifyContent="space-between" alignItems="center" marginBottom={20}>
                 <Text style={styles.modalTitle}>Track a Refund</Text>
-                <Pressable onPress={() => setRefundModalVisible(false)} hitSlop={10}>
+                <Pressable onPress={() => setRefundModal(prev => ({ ...prev, visible: false }))} hitSlop={10}>
                   <Ionicons name="close" size={22} color={DARK_THEME.textSecondary} />
                 </Pressable>
               </XStack>
               <ScrollView bounces={false} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingBottom: 8 }}>
-              {!refundTemplateKey ? (
+              {!refundModal.templateKey ? (
                 /* Template selection */
                 <>
                   <Text style={styles.inputLabel}>Choose a refund type</Text>
@@ -1889,8 +1903,7 @@ export default function BudgetDashboardScreen() {
                       key={tmpl.key}
                       style={styles.templateRow}
                       onPress={() => {
-                        setRefundTemplateKey(tmpl.key);
-                        setRefundDescription(tmpl.label);
+                        setRefundModal(prev => ({ ...prev, templateKey: tmpl.key, description: tmpl.label }));
                       }}
                     >
                       <View style={[styles.refundIcon, { backgroundColor: tmpl.bg }]}>
@@ -1903,7 +1916,7 @@ export default function BudgetDashboardScreen() {
                   {/* Custom refund */}
                   <Pressable
                     style={styles.templateRow}
-                    onPress={() => { setRefundTemplateKey('custom'); setRefundDescription(''); }}
+                    onPress={() => { setRefundModal(prev => ({ ...prev, templateKey: 'custom', description: '' })); }}
                   >
                     <View style={[styles.refundIcon, { backgroundColor: 'rgba(255,255,255,0.05)' }]}>
                       <Ionicons name="add" size={18} color={DARK_THEME.textTertiary} />
@@ -1918,8 +1931,8 @@ export default function BudgetDashboardScreen() {
                   <Text style={styles.inputLabel}>Description</Text>
                   <TextInput
                     style={styles.modalInput}
-                    value={refundDescription}
-                    onChangeText={setRefundDescription}
+                    value={refundModal.description}
+                    onChangeText={v => setRefundModal(prev => ({ ...prev, description: v }))}
                     autoCapitalize="sentences"
                   />
                   <Text style={styles.inputLabel}>Expected Amount (€)</Text>
@@ -1927,18 +1940,18 @@ export default function BudgetDashboardScreen() {
                     style={styles.modalInput}
                     placeholder="0.00"
                     placeholderTextColor={DARK_THEME.textTertiary}
-                    value={refundAmount}
-                    onChangeText={setRefundAmount}
+                    value={refundModal.amount}
+                    onChangeText={v => setRefundModal(prev => ({ ...prev, amount: v }))}
                     keyboardType="decimal-pad"
                   />
                   <Pressable
-                    style={[styles.submitButton, { marginTop: 8 }, (!refundDescription.trim() || !refundAmount.trim()) && styles.submitButtonDisabled]}
+                    style={[styles.submitButton, { marginTop: 8 }, (!refundModal.description.trim() || !refundModal.amount.trim()) && styles.submitButtonDisabled]}
                     onPress={submitRefund}
-                    disabled={!refundDescription.trim() || !refundAmount.trim()}
+                    disabled={!refundModal.description.trim() || !refundModal.amount.trim()}
                   >
                     <Text style={styles.submitButtonText}>Track Refund</Text>
                   </Pressable>
-                  <Pressable style={{ marginTop: 12, marginBottom: 8, alignItems: 'center' }} onPress={() => setRefundTemplateKey(null)}>
+                  <Pressable style={{ marginTop: 12, marginBottom: 8, alignItems: 'center' }} onPress={() => setRefundModal(prev => ({ ...prev, templateKey: null }))}>
                     <Text style={{ color: DARK_THEME.textSecondary, fontSize: 13 }}>← Change type</Text>
                   </Pressable>
                 </>
@@ -1950,9 +1963,9 @@ export default function BudgetDashboardScreen() {
       )}
 
       {/* ─── Custom Category Popup — inline, no Modal (matches destination.tsx drag pattern) ─── */}
-      {customCategoryModalVisible && (
+      {customCatModal.visible && (
         <View style={styles.popupOverlay} pointerEvents="box-none">
-          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setCustomCategoryModalVisible(false)} />
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setCustomCatModal(prev => ({ ...prev, visible: false }))} />
           <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1, justifyContent: 'flex-end' }}>
             <Animated.View style={[styles.modalSheet, { transform: [{ translateY: customCatSheetY }] }]}>
               <View {...customCatSheetPan.panHandlers} style={styles.modalDragHandleArea}>
@@ -1960,7 +1973,7 @@ export default function BudgetDashboardScreen() {
               </View>
               <XStack justifyContent="space-between" alignItems="center" marginBottom={20}>
                 <Text style={styles.modalTitle}>New Category</Text>
-                <Pressable onPress={() => setCustomCategoryModalVisible(false)} hitSlop={10}>
+                <Pressable onPress={() => setCustomCatModal(prev => ({ ...prev, visible: false }))} hitSlop={10}>
                   <Ionicons name="close" size={22} color={DARK_THEME.textSecondary} />
                 </Pressable>
               </XStack>
@@ -1969,20 +1982,20 @@ export default function BudgetDashboardScreen() {
                 style={styles.modalInput}
                 placeholder="e.g. Decorations, Photography..."
                 placeholderTextColor={DARK_THEME.textTertiary}
-                value={customCategoryLabel}
-                onChangeText={setCustomCategoryLabel}
+                value={customCatModal.label}
+                onChangeText={v => setCustomCatModal(prev => ({ ...prev, label: v }))}
                 autoCapitalize="sentences"
                 autoFocus
               />
               <Pressable
-                style={[styles.submitButton, !customCategoryLabel.trim() && styles.submitButtonDisabled]}
-                disabled={!customCategoryLabel.trim()}
+                style={[styles.submitButton, !customCatModal.label.trim() && styles.submitButtonDisabled]}
+                disabled={!customCatModal.label.trim()}
                 onPress={() => {
                   const key = `custom_${Date.now()}`;
                   const customCatColor = CUSTOM_COLORS[customCategories.length % CUSTOM_COLORS.length];
                   const newCat: ExpenseCategory = {
                     key,
-                    labelKey: customCategoryLabel.trim(),
+                    labelKey: customCatModal.label.trim(),
                     icon: 'pricetag-outline',
                     color: customCatColor.color,
                     bg: customCatColor.bg,
@@ -1991,16 +2004,9 @@ export default function BudgetDashboardScreen() {
                   const updated = [...customCategories, newCat];
                   setCustomCategories(updated);
                   saveCustomCategories(updated);
-                  setCustomCategoryModalVisible(false);
+                  setCustomCatModal(prev => ({ ...prev, visible: false }));
                   // Open expense form directly for new category
-                  setExpenseCategoryKey(key);
-                  setExpenseViewMode('form');
-                  setExpenseDescription('');
-                  setExpenseAmount('');
-                  setExpensePaidBy('you');
-                  setExpensePaidByPerson(null);
-                  setExpenseContributors([]);
-                  setExpenseModalVisible(true);
+                  setExpenseModal({ visible: true, categoryKey: key, viewMode: 'form', description: '', amount: '', paidBy: 'you', paidByPerson: null, contributors: [], editingIndex: null, payerDropdownOpen: false });
                 }}
               >
                 <Text style={styles.submitButtonText}>Create & Add Expense</Text>
@@ -2011,7 +2017,7 @@ export default function BudgetDashboardScreen() {
       )}
 
       {/* ─── Remind All Channel Picker (matches Manage Invitations UX) ── */}
-      {remindModalVisible && (() => {
+      {remindModal.visible && (() => {
         const guestList = Object.values(cachedGuests);
         const emailCount = guestList.filter(g => g.email).length;
         const phoneCount = guestList.filter(g => g.phone).length;
@@ -2019,13 +2025,13 @@ export default function BudgetDashboardScreen() {
         const hasPhones = phoneCount > 0;
         return (
           <Modal
-            visible={remindModalVisible}
+            visible={remindModal.visible}
             transparent
             animationType="slide"
-            onRequestClose={() => setRemindModalVisible(false)}
+            onRequestClose={() => setRemindModal(prev => ({ ...prev, visible: false }))}
           >
             <View style={remindStyles.inviteOverlay}>
-              <Pressable style={{ flex: 1 }} onPress={() => setRemindModalVisible(false)} />
+              <Pressable style={{ flex: 1 }} onPress={() => setRemindModal(prev => ({ ...prev, visible: false }))} />
               <View style={remindStyles.inviteSheet}>
                 {/* Handle */}
                 <View style={remindStyles.inviteHandle} />
@@ -2033,19 +2039,19 @@ export default function BudgetDashboardScreen() {
                 {/* Header */}
                 <XStack justifyContent="space-between" alignItems="center" marginBottom={16}>
                   <Text style={remindStyles.inviteTitle}>
-                    {remindSendStatus === 'done'
-                      ? `${remindActiveChannel === 'email' ? 'Email' : remindActiveChannel === 'sms' ? 'SMS' : 'WhatsApp'} sent`
+                    {remindModal.sendStatus === 'done'
+                      ? `${remindModal.activeChannel === 'email' ? 'Email' : remindModal.activeChannel === 'sms' ? 'SMS' : 'WhatsApp'} sent`
                       : 'Remind All Guests'}
                   </Text>
-                  {remindSendStatus !== 'sending' && (
-                    <Pressable onPress={() => setRemindModalVisible(false)} hitSlop={10}>
+                  {remindModal.sendStatus !== 'sending' && (
+                    <Pressable onPress={() => setRemindModal(prev => ({ ...prev, visible: false }))} hitSlop={10}>
                       <Ionicons name="close" size={22} color={DARK_THEME.textSecondary} />
                     </Pressable>
                   )}
                 </XStack>
 
                 {/* idle: horizontal 3 channel buttons */}
-                {remindSendStatus === 'idle' && (
+                {remindModal.sendStatus === 'idle' && (
                   <>
                     <Text style={remindStyles.inviteSectionLabel}>SEND PAYMENT REMINDER VIA</Text>
                     <XStack gap={10} marginBottom={20}>
@@ -2078,24 +2084,24 @@ export default function BudgetDashboardScreen() {
                 )}
 
                 {/* sending: spinner */}
-                {remindSendStatus === 'sending' && (
+                {remindModal.sendStatus === 'sending' && (
                   <View style={{ alignItems: 'center', paddingVertical: 32, gap: 16 }}>
                     <ActivityIndicator size="large" color="#5A7EB0" />
                     <Text style={{ fontSize: 15, fontWeight: '600', color: DARK_THEME.textPrimary }}>
-                      Sending {remindActiveChannel === 'email' ? 'email' : remindActiveChannel === 'sms' ? 'SMS' : 'WhatsApp'} reminders…
+                      Sending {remindModal.activeChannel === 'email' ? 'email' : remindModal.activeChannel === 'sms' ? 'SMS' : 'WhatsApp'} reminders…
                     </Text>
                   </View>
                 )}
 
                 {/* done: results */}
-                {remindSendStatus === 'done' && (
+                {remindModal.sendStatus === 'done' && (
                   <>
                     <View style={{ backgroundColor: DARK_THEME.deepNavy, borderRadius: 12, padding: 12, marginBottom: 16 }}>
                       <Text style={{ fontSize: 13, color: DARK_THEME.textSecondary, marginBottom: 8 }}>
-                        {remindResults.filter(r => r.status === 'sent').length} sent ·{' '}
-                        {remindResults.filter(r => r.status === 'failed').length} failed
+                        {remindModal.results.filter(r => r.status === 'sent').length} sent ·{' '}
+                        {remindModal.results.filter(r => r.status === 'failed').length} failed
                       </Text>
-                      {remindResults.map((r, i) => (
+                      {remindModal.results.map((r, i) => (
                         <XStack key={i} alignItems="center" gap={10} paddingVertical={6}
                           style={{ borderBottomWidth: 1, borderBottomColor: 'rgba(255,255,255,0.05)' }}>
                           <Ionicons
@@ -2111,7 +2117,7 @@ export default function BudgetDashboardScreen() {
                     </View>
                     <Pressable
                       style={[remindStyles.inviteChannelBtn, { flex: 0, paddingHorizontal: 20 }]}
-                      onPress={() => { setRemindSendStatus('idle'); setRemindResults([]); setRemindActiveChannel(null); }}
+                      onPress={() => { setRemindModal(prev => ({ ...prev, sendStatus: 'idle', results: [], activeChannel: null })); }}
                     >
                       <Text style={[remindStyles.inviteChannelLabel, { color: '#5A7EB0' }]}>Send via another channel</Text>
                     </Pressable>

--- a/game-over-app/app/(tabs)/chat/index.tsx
+++ b/game-over-app/app/(tabs)/chat/index.tsx
@@ -3,7 +3,7 @@
  * Chat, Voting, Decisions with organized channel sections
  */
 
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { Animated, PanResponder, ScrollView, RefreshControl, Pressable, StyleSheet, View, StatusBar, Alert, TextInput, KeyboardAvoidingView, Platform } from 'react-native';
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -21,6 +21,7 @@ import { DARK_THEME } from '@/constants/theme';
 import { useTranslation, getTranslation } from '@/i18n';
 import { useSwipeTabs } from '@/hooks/useSwipeTabs';
 import { useUser } from '@/stores/authStore';
+import { useTabBarStore } from '@/stores/tabBarStore';
 import { getEventImage, resolveImageSource } from '@/constants/packageImages';
 import type { Database } from '@/lib/supabase/types';
 
@@ -526,6 +527,16 @@ export default function CommunicationScreen() {
         }
       });
     }, [])
+  );
+
+  const setTabBarHidden = useTabBarStore((s) => s.setHidden);
+
+  // Hide tab bar when accessed from Event Summary (eventId present in URL)
+  useFocusEffect(
+    useCallback(() => {
+      if (eventIdParam) setTabBarHidden(true);
+      return () => setTabBarHidden(false);
+    }, [eventIdParam, setTabBarHidden])
   );
 
   // Fetch user's events

--- a/game-over-app/app/booking/[eventId]/confirmation.tsx
+++ b/game-over-app/app/booking/[eventId]/confirmation.tsx
@@ -268,7 +268,7 @@ export default function BookingConfirmationScreen() {
                   <Ionicons
                     name={copied ? 'checkmark-circle' : 'copy-outline'}
                     size={18}
-                    color={copied ? '#47B881' : '#258CF4'}
+                    color={copied ? '#47B881' : '#5A7EB0'}
                   />
                 </XStack>
               </Pressable>
@@ -316,25 +316,25 @@ export default function BookingConfirmationScreen() {
         </Card>
 
         {/* Next Steps */}
-        <Card width="100%" marginHorizontal="$4" paddingHorizontal={16} backgroundColor="rgba(37, 140, 244, 0.1)" borderWidth={0}>
+        <Card width="100%" marginHorizontal="$4" paddingHorizontal={16} backgroundColor="rgba(90, 126, 176, 0.1)" borderWidth={0}>
           <YStack gap="$3">
             <Text fontSize="$4" fontWeight="700" color="$primary" textAlign="center">
               {t.booking.whatsNext}
             </Text>
             <XStack gap="$2" alignItems="flex-start">
-              <Ionicons name="mail-outline" size={18} color="#258CF4" style={{ marginTop: 2 }} />
+              <Ionicons name="mail-outline" size={18} color="#5A7EB0" style={{ marginTop: 2 }} />
               <Text fontSize="$2" color="$textSecondary" flex={1}>
                 {t.booking.confirmationEmail}
               </Text>
             </XStack>
             <XStack gap="$2" alignItems="flex-start">
-              <Ionicons name="people-outline" size={18} color="#258CF4" style={{ marginTop: 2 }} />
+              <Ionicons name="people-outline" size={18} color="#5A7EB0" style={{ marginTop: 2 }} />
               <Text fontSize="$2" color="$textSecondary" flex={1}>
                 {t.booking.inviteGuests}
               </Text>
             </XStack>
             <XStack gap="$2" alignItems="flex-start">
-              <Ionicons name="chatbubbles-outline" size={18} color="#258CF4" style={{ marginTop: 2 }} />
+              <Ionicons name="chatbubbles-outline" size={18} color="#5A7EB0" style={{ marginTop: 2 }} />
               <Text fontSize="$2" color="$textSecondary" flex={1}>
                 {t.booking.useGroupChat}
               </Text>
@@ -359,7 +359,7 @@ export default function BookingConfirmationScreen() {
           testID="add-to-calendar-button"
         >
           <XStack gap="$2" alignItems="center">
-            <Ionicons name="calendar-outline" size={20} color="#258CF4" />
+            <Ionicons name="calendar-outline" size={20} color="#5A7EB0" />
             <Text color="$primary" fontWeight="600">
               {t.booking.addToCalendar}
             </Text>

--- a/game-over-app/app/booking/[eventId]/payment.tsx
+++ b/game-over-app/app/booking/[eventId]/payment.tsx
@@ -453,7 +453,7 @@ export default function PaymentScreen() {
                   alignItems="center"
                   gap="$3"
                 >
-                  <Ionicons name="card" size={24} color="#258CF4" />
+                  <Ionicons name="card" size={24} color="#5A7EB0" />
                   <YStack flex={1}>
                     <Text fontWeight="600" color="$textPrimary">
                       {t.booking.creditOrDebit}
@@ -462,7 +462,7 @@ export default function PaymentScreen() {
                       {t.booking.visaMastercard}
                     </Text>
                   </YStack>
-                  <Ionicons name="checkmark-circle" size={24} color="#258CF4" />
+                  <Ionicons name="checkmark-circle" size={24} color="#5A7EB0" />
                 </XStack>
 
                 {/* Apple Pay — Coming Soon */}
@@ -522,11 +522,11 @@ export default function PaymentScreen() {
                   width={48}
                   height={48}
                   borderRadius="$md"
-                  backgroundColor="rgba(37, 140, 244, 0.1)"
+                  backgroundColor="rgba(90, 126, 176, 0.1)"
                   alignItems="center"
                   justifyContent="center"
                 >
-                  <Ionicons name="gift" size={24} color="#258CF4" />
+                  <Ionicons name="gift" size={24} color="#5A7EB0" />
                 </YStack>
                 <YStack flex={1}>
                   <Text fontWeight="600" color="$textPrimary">

--- a/game-over-app/app/create-event/review.tsx
+++ b/game-over-app/app/create-event/review.tsx
@@ -210,7 +210,7 @@ export default function WizardStep5() {
         {/* Info Banner */}
         <XStack
           padding="$4"
-          backgroundColor="rgba(37, 140, 244, 0.1)"
+          backgroundColor="rgba(90, 126, 176, 0.1)"
           borderRadius="$lg"
           gap="$3"
           alignItems="flex-start"

--- a/game-over-app/app/event/[id]/communication.tsx
+++ b/game-over-app/app/event/[id]/communication.tsx
@@ -239,7 +239,7 @@ export default function CommunicationCenterScreen() {
             position="absolute"
             top={16}
             right={16}
-            backgroundColor="#4A6FA5"
+            backgroundColor="#5A7EB0"
             paddingHorizontal={6}
             paddingVertical={2}
             borderRadius="$full"
@@ -270,13 +270,13 @@ export default function CommunicationCenterScreen() {
           style={styles.newPollButton}
           onPress={() => setShowCreatePollModal(true)}
         >
-          <Text fontSize={12} color="#4A6FA5" fontWeight="500">New Poll</Text>
-          <Ionicons name="add" size={16} color="#4A6FA5" />
+          <Text fontSize={12} color="#5A7EB0" fontWeight="500">New Poll</Text>
+          <Ionicons name="add" size={16} color="#5A7EB0" />
         </Pressable>
       )}
       {activeTab === 'chat' && section.category !== 'general' && (
         <Pressable>
-          <Ionicons name="add" size={18} color="#4A6FA5" />
+          <Ionicons name="add" size={18} color="#5A7EB0" />
         </Pressable>
       )}
     </XStack>
@@ -304,7 +304,7 @@ export default function CommunicationCenterScreen() {
     if (channelsLoading) {
       return (
         <YStack flex={1} justifyContent="center" alignItems="center">
-          <Spinner size="large" color="#4A6FA5" />
+          <Spinner size="large" color="#5A7EB0" />
         </YStack>
       );
     }
@@ -321,7 +321,7 @@ export default function CommunicationCenterScreen() {
             justifyContent="center"
             marginBottom="$4"
           >
-            <Ionicons name="chatbubbles-outline" size={40} color="#4A6FA5" />
+            <Ionicons name="chatbubbles-outline" size={40} color="#5A7EB0" />
           </YStack>
           <Text fontSize={16} fontWeight="700" color="white" marginBottom="$2">
             No Channels Yet
@@ -344,7 +344,7 @@ export default function CommunicationCenterScreen() {
           <RefreshControl
             refreshing={isRefetchingChannels}
             onRefresh={handleRefresh}
-            tintColor="#4A6FA5"
+            tintColor="#5A7EB0"
           />
         }
         contentContainerStyle={styles.listContent}
@@ -357,7 +357,7 @@ export default function CommunicationCenterScreen() {
     if (pollsLoading) {
       return (
         <YStack flex={1} justifyContent="center" alignItems="center">
-          <Spinner size="large" color="#4A6FA5" />
+          <Spinner size="large" color="#5A7EB0" />
         </YStack>
       );
     }
@@ -374,7 +374,7 @@ export default function CommunicationCenterScreen() {
             justifyContent="center"
             marginBottom="$4"
           >
-            <Ionicons name="bar-chart-outline" size={40} color="#4A6FA5" />
+            <Ionicons name="bar-chart-outline" size={40} color="#5A7EB0" />
           </YStack>
           <Text fontSize={16} fontWeight="700" color="white" marginBottom="$2">
             No Active Polls
@@ -409,7 +409,7 @@ export default function CommunicationCenterScreen() {
           <RefreshControl
             refreshing={isRefetchingPolls}
             onRefresh={handleRefresh}
-            tintColor="#4A6FA5"
+            tintColor="#5A7EB0"
           />
         }
         contentContainerStyle={styles.listContent}
@@ -422,7 +422,7 @@ export default function CommunicationCenterScreen() {
     if (pollsLoading) {
       return (
         <YStack flex={1} justifyContent="center" alignItems="center">
-          <Spinner size="large" color="#4A6FA5" />
+          <Spinner size="large" color="#5A7EB0" />
         </YStack>
       );
     }
@@ -464,7 +464,7 @@ export default function CommunicationCenterScreen() {
           <RefreshControl
             refreshing={isRefetchingPolls}
             onRefresh={handleRefresh}
-            tintColor="#4A6FA5"
+            tintColor="#5A7EB0"
           />
         }
         contentContainerStyle={styles.listContent}
@@ -612,10 +612,10 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   tabActive: {
-    backgroundColor: '#4A6FA5',
+    backgroundColor: '#5A7EB0',
   },
   shareEventBanner: {
-    backgroundColor: '#4A6FA5',
+    backgroundColor: '#5A7EB0',
     borderRadius: 16,
     padding: 20,
     position: 'relative',
@@ -676,7 +676,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    backgroundColor: '#4A6FA5',
+    backgroundColor: '#5A7EB0',
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 12,

--- a/game-over-app/app/event/[id]/index.tsx
+++ b/game-over-app/app/event/[id]/index.tsx
@@ -46,7 +46,7 @@ export default function EventSummaryScreen() {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
 
-  const { data: event, isLoading: eventLoading } = useEvent(id);
+  const { data: event, isLoading: eventLoading, error: eventError, refetch: refetchEvent } = useEvent(id);
   const { data: participants, isLoading: isLoadingParticipants } = useParticipants(id);
   const { data: booking } = useBooking(id);
   const currentUserId = useAuthStore(s => s.user?.id);
@@ -219,9 +219,9 @@ export default function EventSummaryScreen() {
     if (!event || !id) return;
     if (isGuest) {
       Alert.alert(
-        'Organizer Only',
-        'Only the event organizer can manage planning steps.',
-        [{ text: 'OK' }]
+        t.eventDetail.organizerOnly,
+        t.eventDetail.organizerOnlyMsg,
+        [{ text: t.common.ok }]
       );
       return;
     }
@@ -243,6 +243,28 @@ export default function EventSummaryScreen() {
       },
     });
   };
+
+  // ─── Error state ───────────────────────────────
+  if (eventError && !event) {
+    return (
+      <YStack flex={1} backgroundColor={DARK_THEME.background} justifyContent="center" alignItems="center" padding={24}>
+        <Ionicons name="cloud-offline-outline" size={48} color={DARK_THEME.textTertiary} />
+        <Text color={DARK_THEME.textPrimary} fontSize={16} fontWeight="600" marginTop={16} marginBottom={8} textAlign="center">
+          {t.common.error}
+        </Text>
+        <Text color={DARK_THEME.textSecondary} fontSize={14} textAlign="center" marginBottom={24}>
+          {t.events.loadError}
+        </Text>
+        <Pressable
+          onPress={() => refetchEvent()}
+          style={{ backgroundColor: DARK_THEME.primary, paddingHorizontal: 24, paddingVertical: 12, borderRadius: 12 }}
+          testID="event-detail-retry-button"
+        >
+          <Text color="#FFFFFF" fontWeight="600">{t.common.retry}</Text>
+        </Pressable>
+      </YStack>
+    );
+  }
 
   // ─── Loading skeleton ──────────────────────────
   if (eventLoading || !event) {
@@ -304,7 +326,7 @@ export default function EventSummaryScreen() {
           color: DARK_THEME.textTertiary,
         };
       case 'packages':
-        return { text: 'View Package Details', color: DARK_THEME.textTertiary };
+        return { text: t.eventDetail.selectedPackage, color: DARK_THEME.textTertiary };
       default:
         return { text: '', color: DARK_THEME.textTertiary };
     }
@@ -415,7 +437,7 @@ export default function EventSummaryScreen() {
                 onPress={() => {
                   if (tool.key === 'packages') {
                     // Navigate to the actual package detail screen with event context
-                    const pkgId = cachedBudget?.packageId || bookingPkgId;
+                    const pkgId = cachedBudget?.packageId || booking?.package_id;
                     if (pkgId) {
                       router.push(`/package/${pkgId}?eventId=${id}&viewOnly=1` as any);
                     }

--- a/game-over-app/app/event/[id]/polls.tsx
+++ b/game-over-app/app/event/[id]/polls.tsx
@@ -11,7 +11,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePolls, useCreatePoll, useVote } from '@/hooks/queries/usePolls';
 import { PollCard, CreatePollModal } from '@/components/polls';
-import { colors } from '@/constants/colors';
+import { DARK_THEME } from '@/constants/theme';
 import type { Database } from '@/lib/supabase/types';
 
 type PollCategory = Database['public']['Tables']['polls']['Row']['category'];
@@ -179,8 +179,8 @@ export default function PollsScreen() {
           <RefreshControl
             refreshing={isRefetching}
             onRefresh={refetch}
-            colors={[colors.light.primary]}
-            tintColor={colors.light.primary}
+            colors={[DARK_THEME.primary]}
+            tintColor={DARK_THEME.primary}
           />
         }
         ListEmptyComponent={
@@ -189,7 +189,7 @@ export default function PollsScreen() {
               width={80}
               height={80}
               borderRadius="$full"
-              backgroundColor={`${colors.light.primary}15`}
+              backgroundColor="rgba(90, 126, 176, 0.08)"
               alignItems="center"
               justifyContent="center"
               marginBottom="$4"
@@ -197,7 +197,7 @@ export default function PollsScreen() {
               <Ionicons
                 name={filter === 'closed' ? 'checkmark-done' : 'bar-chart-outline'}
                 size={40}
-                color={colors.light.primary}
+                color={DARK_THEME.primary}
               />
             </YStack>
             <Text fontSize="$4" fontWeight="700" color="$textPrimary" marginBottom="$2">
@@ -239,7 +239,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: colors.light.primary,
+    backgroundColor: DARK_THEME.primary,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -247,13 +247,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 6,
     borderRadius: 16,
-    backgroundColor: colors.light.background,
+    backgroundColor: DARK_THEME.surface,
     borderWidth: 1,
-    borderColor: colors.light.border,
+    borderColor: DARK_THEME.glassBorder,
   },
   filterChipSelected: {
-    backgroundColor: colors.light.primary,
-    borderColor: colors.light.primary,
+    backgroundColor: DARK_THEME.primary,
+    borderColor: DARK_THEME.primary,
   },
   listContent: {
     paddingTop: 16,
@@ -264,7 +264,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    backgroundColor: colors.light.primary,
+    backgroundColor: DARK_THEME.primary,
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 12,

--- a/game-over-app/app/event/[id]/polls.tsx
+++ b/game-over-app/app/event/[id]/polls.tsx
@@ -117,7 +117,7 @@ export default function PollsScreen() {
           onPress={() => router.back()}
           testID="back-button"
         >
-          <Ionicons name="arrow-back" size={24} color="#1A202C" />
+          <Ionicons name="arrow-back" size={24} color={DARK_THEME.textPrimary} />
         </XStack>
 
         <YStack flex={1}>

--- a/game-over-app/app/invite/[code].tsx
+++ b/game-over-app/app/invite/[code].tsx
@@ -22,6 +22,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 import { supabase } from '@/lib/supabase/client';
 import { useAuthStore } from '@/stores/authStore';
+import { useLanguageStore } from '@/stores/languageStore';
 import { usePublicInvitePreview, useAcceptInvite } from '@/hooks/queries/useInvites';
 import { getPackageImage, resolveImageSource } from '@/constants/packageImages';
 import { CITY_UUID_TO_SLUG } from '@/constants/citySlugMap';
@@ -61,6 +62,7 @@ export default function InviteWizardScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const user = useAuthStore(s => s.user);
+  const language = useLanguageStore(s => s.language);
 
   const [step, setStep] = useState<WizardStep>('preview');
   const [avatarUri, setAvatarUri] = useState<string | null>(null);
@@ -353,7 +355,7 @@ export default function InviteWizardScreen() {
           <View style={{ position: 'absolute', bottom: 24, left: 24, right: 24 }}>
             <Text fontSize={26} fontWeight="900" color="white">{preview.eventName}</Text>
             <Text fontSize={15} color="rgba(255,255,255,0.8)" marginTop={4}>
-              {new Date(preview.startDate).toLocaleDateString('en-US', {
+              {new Date(preview.startDate).toLocaleDateString(language === 'de' ? 'de-DE' : 'en-US', {
                 month: 'long', day: 'numeric', year: 'numeric',
               })} · {preview.cityName}
             </Text>
@@ -465,13 +467,7 @@ export default function InviteWizardScreen() {
                 />
               )}
             />
-            {signupForm.formState.errors.email?.message?.includes('Log in instead') && (
-              <Pressable onPress={handleLoginInstead}>
-                <Text fontSize={13} color={DARK_THEME.primary} textDecorationLine="underline">
-                  Log in instead →
-                </Text>
-              </Pressable>
-            )}
+{/* Persistent login link below the form supersedes this conditional — removed to avoid duplicate */}
             <Controller
               control={signupForm.control}
               name="password"

--- a/game-over-app/app/invite/[code].tsx
+++ b/game-over-app/app/invite/[code].tsx
@@ -375,7 +375,17 @@ export default function InviteWizardScreen() {
               Accept Invitation →
             </Button>
 
-            <Pressable onPress={() => router.back()} style={{ alignItems: 'center', paddingVertical: 8 }}>
+            <Pressable
+              onPress={() => {
+                if (router.canGoBack()) {
+                  router.back();
+                } else {
+                  router.replace('/(tabs)/events');
+                }
+              }}
+              style={{ alignItems: 'center', paddingVertical: 8 }}
+              testID="decline-invite-button"
+            >
               <Text fontSize={13} color="$textTertiary">Decline</Text>
             </Pressable>
           </YStack>
@@ -500,6 +510,20 @@ export default function InviteWizardScreen() {
             >
               Create Account →
             </Button>
+
+            {/* Persistent link — visible before any error occurs */}
+            <Pressable
+              onPress={handleLoginInstead}
+              style={{ alignItems: 'center', paddingVertical: 12 }}
+              testID="login-instead-link"
+            >
+              <Text fontSize={13} color={DARK_THEME.textTertiary}>
+                Already have an account?{' '}
+                <Text color={DARK_THEME.primary} textDecorationLine="underline">
+                  Log in instead →
+                </Text>
+              </Text>
+            </Pressable>
           </ScrollView>
         </YStack>
       </KeyboardAvoidingView>

--- a/game-over-app/app/notifications/index.tsx
+++ b/game-over-app/app/notifications/index.tsx
@@ -4,8 +4,10 @@
  * Matches the dark theme design from UI specifications
  */
 
-import React, { useCallback, useMemo } from 'react';
-import { RefreshControl, Pressable, StyleSheet, SectionList, View } from 'react-native';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import { Alert, RefreshControl, Pressable, StyleSheet, SectionList, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { YStack, XStack, Text, Spinner } from 'tamagui';
 import { Ionicons } from '@expo/vector-icons';
@@ -21,6 +23,9 @@ import { NotificationItem } from '@/components/notifications';
 import { useTranslation } from '@/i18n';
 import { useUrgentPayment } from '@/hooks/useUrgentPayment';
 import { DARK_THEME } from '@/constants/theme';
+import { useParticipants, participantKeys } from '@/hooks/queries/useParticipants';
+import { useUser } from '@/stores/authStore';
+import { supabase } from '@/lib/supabase/client';
 import type { Database } from '@/lib/supabase/types';
 
 type Notification = Database['public']['Tables']['notifications']['Row'];
@@ -29,9 +34,71 @@ export default function NotificationsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
+  const user = useUser();
+  const queryClient = useQueryClient();
+  const [guestPayConfirming, setGuestPayConfirming] = useState(false);
+  const [guestPayConfirmed, setGuestPayConfirmed] = useState(false);
 
   // All hooks at the top — no conditional calls
-  const { urgentEvents } = useUrgentPayment();
+  const { urgentEvents, guestUrgentEvent, guestPaidRecentEvent, isGuestContribution } = useUrgentPayment();
+
+  // isOrganizer: true only if user created the guest-relevant event.
+  // Check guestUrgentEvent first; fall back to guestPaidRecentEvent (shown after payment).
+  // Never default to true — that would hide the "Contribution Confirmed" card.
+  const relevantGuestEvent = guestUrgentEvent ?? guestPaidRecentEvent;
+  const isOrganizer = relevantGuestEvent ? relevantGuestEvent.created_by === user?.id : false;
+
+  // Persist "payment confirmed" in AsyncStorage so the card survives navigation.
+  const GUEST_PAID_KEY = user?.id ? `gameover:guest_paid_confirmed:${user.id}` : null;
+  useEffect(() => {
+    if (!GUEST_PAID_KEY) return;
+    AsyncStorage.getItem(GUEST_PAID_KEY).then(val => {
+      if (val === '1') setGuestPayConfirmed(true);
+    }).catch(() => {});
+  }, [GUEST_PAID_KEY]);
+
+  // Load participants for the guest's urgent event (to show organizer name)
+  const { data: guestEventParticipants } = useParticipants(guestUrgentEvent?.id);
+  const organizerName = guestEventParticipants?.find(p => p.role === 'organizer')?.profile?.full_name ?? 'the organizer';
+
+  const handleGuestMarkAsPaid = () => {
+    Alert.alert(
+      t.notifications.confirmPayment,
+      t.notifications.confirmPaymentMsg.replace('{{name}}', organizerName),
+      [
+        { text: t.notifications.notYet, style: 'cancel' },
+        {
+          text: t.notifications.yesPaid,
+          onPress: async () => {
+            if (!guestUrgentEvent?.id || !user?.id) return;
+            setGuestPayConfirming(true);
+            try {
+              await supabase
+                .from('event_participants')
+                .update({ payment_status: 'paid' })
+                .eq('event_id', guestUrgentEvent.id)
+                .eq('user_id', user.id);
+              void supabase.from('notifications').insert({
+                event_id: guestUrgentEvent.id,
+                title: 'Payment Confirmed',
+                body: `A guest has confirmed their payment for ${guestUrgentEvent.title || `${guestUrgentEvent.honoree_name}'s event`}.`,
+                type: 'payment_confirmed',
+                user_id: user.id,
+              });
+              queryClient.invalidateQueries({ queryKey: participantKeys.byEvent(guestUrgentEvent.id) });
+              queryClient.invalidateQueries({ queryKey: ['guestParticipations', user?.id] });
+              setGuestPayConfirmed(true);
+              if (GUEST_PAID_KEY) AsyncStorage.setItem(GUEST_PAID_KEY, '1').catch(() => {});
+            } catch (e: any) {
+              Alert.alert(t.common.error, e.message || t.notifications.errorConfirmPayment);
+            } finally {
+              setGuestPayConfirming(false);
+            }
+          },
+        },
+      ]
+    );
+  };
 
   // Fetch notifications
   const {
@@ -127,7 +194,8 @@ export default function NotificationsScreen() {
   }
 
   const hasNotifications = groupedNotifications.length > 0;
-  const hasAnyContent = hasNotifications || urgentEvents.length > 0;
+  const organizerUrgentEvents = urgentEvents.filter(info => info.event.created_by === user?.id);
+  const hasAnyContent = hasNotifications || organizerUrgentEvents.length > 0 || isGuestContribution || !!guestPaidRecentEvent || guestPayConfirmed;
 
   return (
     <YStack flex={1} backgroundColor={DARK_THEME.background} testID="notifications-screen">
@@ -178,7 +246,7 @@ export default function NotificationsScreen() {
           stickySectionHeadersEnabled={false}
           contentContainerStyle={styles.listContent}
           ListHeaderComponent={
-            urgentEvents.length > 0 ? (
+            (organizerUrgentEvents.length > 0 || (isGuestContribution && !isOrganizer) || ((!!guestPaidRecentEvent || guestPayConfirmed) && !isOrganizer)) ? (
               <>
                 {/* TODAY label above all urgency rows */}
                 <YStack paddingHorizontal="$4" paddingTop="$3" paddingBottom="$1" marginLeft="$1">
@@ -192,8 +260,77 @@ export default function NotificationsScreen() {
                   </Text>
                 </YStack>
 
-                {/* One row per urgent event, sorted soonest first */}
-                {urgentEvents.map((info) => (
+                {/* Guest: payment confirmed card (shown after marking as paid — persists via AsyncStorage) */}
+                {!isGuestContribution && !isOrganizer && (guestPaidRecentEvent || guestPayConfirmed) && (
+                  <View style={[styles.guestPayCard, { borderColor: 'rgba(52, 211, 153, 0.25)', backgroundColor: 'rgba(52, 211, 153, 0.07)' }]}>
+                    <XStack alignItems="center" gap={12}>
+                      <View style={[styles.urgencyIconCircle, { backgroundColor: 'rgba(52, 211, 153, 0.18)' }]}>
+                        <Ionicons name="checkmark-circle" size={18} color="#34D399" />
+                      </View>
+                      <YStack flex={1}>
+                        <Text style={{ fontSize: 14, fontWeight: '700', color: '#34D399' }}>
+                          Contribution Confirmed
+                        </Text>
+                        <Text style={{ fontSize: 12, color: DARK_THEME.textSecondary }} numberOfLines={1}>
+                          {guestPaidRecentEvent?.title || (guestPaidRecentEvent?.honoree_name ? `${guestPaidRecentEvent.honoree_name}'s Event` : 'Your Event')}
+                        </Text>
+                      </YStack>
+                      <Ionicons name="checkmark-circle" size={20} color="#34D399" />
+                    </XStack>
+                    <Text style={{ fontSize: 13, color: DARK_THEME.textSecondary, lineHeight: 20, marginTop: 10 }}>
+                      Your payment has been confirmed. The organizer has been notified.
+                    </Text>
+                  </View>
+                )}
+
+                {/* Guest: contribution due + "I've Paid" button */}
+                {isGuestContribution && !isOrganizer && guestUrgentEvent && (
+                  <View style={styles.guestPayCard}>
+                    <XStack alignItems="center" gap={12} marginBottom={10}>
+                      <View style={[styles.urgencyIconCircle, { backgroundColor: 'rgba(249, 115, 22, 0.18)' }]}>
+                        <Ionicons name="wallet-outline" size={18} color="#F97316" />
+                      </View>
+                      <YStack flex={1}>
+                        <Text style={{ fontSize: 14, fontWeight: '700', color: '#F97316' }}>
+                          Contribution Due
+                        </Text>
+                        <Text style={{ fontSize: 12, color: DARK_THEME.textSecondary }} numberOfLines={1}>
+                          {guestUrgentEvent.title || `${guestUrgentEvent.honoree_name}'s Event`}
+                        </Text>
+                      </YStack>
+                      <View style={styles.urgencyBadge}>
+                        <Text style={styles.urgencyBadgeText}>URGENT</Text>
+                      </View>
+                    </XStack>
+                    <Text style={{ fontSize: 13, color: DARK_THEME.textSecondary, lineHeight: 20, marginBottom: 12 }}>
+                      Please transfer your share to{' '}
+                      <Text style={{ color: DARK_THEME.textPrimary, fontWeight: '600' }}>{organizerName}</Text>.
+                      {' '}Payment is due 14 days before the event.
+                    </Text>
+                    {guestPayConfirmed ? (
+                      <XStack alignItems="center" gap={8} justifyContent="center">
+                        <Ionicons name="checkmark-circle" size={18} color="#10B981" />
+                        <Text style={{ fontSize: 14, fontWeight: '600', color: '#10B981' }}>
+                          Payment confirmed — organizer notified
+                        </Text>
+                      </XStack>
+                    ) : (
+                      <Pressable
+                        style={[styles.guestPayButton, guestPayConfirming && { opacity: 0.6 }]}
+                        onPress={handleGuestMarkAsPaid}
+                        disabled={guestPayConfirming}
+                      >
+                        <Ionicons name="checkmark-circle-outline" size={18} color="#FFFFFF" />
+                        <Text style={{ fontSize: 14, fontWeight: '700', color: '#FFFFFF' }}>
+                          {guestPayConfirming ? 'Confirming…' : "I've Paid — Confirm"}
+                        </Text>
+                      </Pressable>
+                    )}
+                  </View>
+                )}
+
+                {/* One row per urgent event (organizer-owned only), sorted soonest first */}
+                {organizerUrgentEvents.map((info) => (
                   <React.Fragment key={info.event.id}>
                     <Pressable
                       style={[styles.urgencyRow, info.isPaid && styles.urgencyRowPaid]}
@@ -358,5 +495,36 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: 'rgba(255, 255, 255, 0.05)',
     marginLeft: 68,
+  },
+  guestPayCard: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    marginBottom: 8,
+    backgroundColor: 'rgba(249, 115, 22, 0.07)',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(249, 115, 22, 0.25)',
+    padding: 16,
+  },
+  guestPayButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: DARK_THEME.primary,
+    borderRadius: 12,
+    paddingVertical: 12,
+  },
+  urgencyBadge: {
+    backgroundColor: 'rgba(249, 115, 22, 0.15)',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  urgencyBadgeText: {
+    fontSize: 10,
+    fontWeight: '700' as const,
+    color: '#F97316',
+    letterSpacing: 0.5,
   },
 });

--- a/game-over-app/app/notifications/index.tsx
+++ b/game-over-app/app/notifications/index.tsx
@@ -73,11 +73,12 @@ export default function NotificationsScreen() {
             if (!guestUrgentEvent?.id || !user?.id) return;
             setGuestPayConfirming(true);
             try {
-              await supabase
+              const { error: updateError } = await supabase
                 .from('event_participants')
                 .update({ payment_status: 'paid' })
                 .eq('event_id', guestUrgentEvent.id)
                 .eq('user_id', user.id);
+              if (updateError) throw updateError;
               void supabase.from('notifications').insert({
                 event_id: guestUrgentEvent.id,
                 title: 'Payment Confirmed',

--- a/game-over-app/app/package/[id].tsx
+++ b/game-over-app/app/package/[id].tsx
@@ -152,7 +152,7 @@ function HighlightCard({ icon, label, sub }: { icon: string; label: string; sub:
         width={40}
         height={40}
         borderRadius="$full"
-        backgroundColor="rgba(37, 140, 244, 0.15)"
+        backgroundColor="rgba(90, 126, 176, 0.15)"
         alignItems="center"
         justifyContent="center"
       >
@@ -175,7 +175,7 @@ function IncludeItem({ icon, title, sub }: { icon: string; title: string; sub: s
         width={36}
         height={36}
         borderRadius="$full"
-        backgroundColor="rgba(37, 140, 244, 0.15)"
+        backgroundColor="rgba(90, 126, 176, 0.15)"
         alignItems="center"
         justifyContent="center"
         marginTop={2}

--- a/game-over-app/docs/superpowers/plans/2026-03-20-tier1-quality-security-fixes.md
+++ b/game-over-app/docs/superpowers/plans/2026-03-20-tier1-quality-security-fixes.md
@@ -1,0 +1,1350 @@
+# Tier 1 Quality & Security Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all critical/high/medium findings from the Software Architect, Code Reviewer, and Security Engineer agent reports — without breaking existing functionality.
+
+**Architecture:** Three sequential phases in a dedicated worktree (`fix/tier1-quality-and-security`). Each phase ends with a TypeScript check. Security phase includes edge function changes (Supabase Deno, not npm).
+
+**Tech Stack:** TypeScript, React Native/Expo, Zustand, React Query, Supabase (PostgreSQL + Edge Functions/Deno), Zod
+
+**Worktree path:** `/Users/soleilphoenix/Desktop/GameOver-quality-fixes/`
+**Branch:** `fix/tier1-quality-and-security`
+**Verify command:** `cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck`
+
+---
+
+## PHASE 1: Software Architect Fixes
+
+### Task 1.1: Consolidate Pricing Logic into `src/utils/pricing.ts`
+
+**Why:** Three independent pricing implementations produce different totals for the same inputs. This is a financial correctness risk.
+
+**Files:**
+- Create: `src/utils/pricing.ts`
+- Modify: `src/repositories/bookings.ts` (delegate `calculateCosts` to new utility)
+- Modify: `src/hooks/useBookingFlow.ts` (delegate pricing `useMemo` to new utility)
+
+- [ ] **Step 1: Create canonical pricing utility**
+
+```typescript
+// src/utils/pricing.ts
+
+export const SERVICE_FEE_PERCENTAGE = 0.10; // 10%
+export const MIN_SERVICE_FEE_CENTS = 5000;  // €50
+
+export interface PackagePricingInput {
+  pricePerPersonCents: number;
+  baseFeeCents?: number; // some packages have an additional base fee
+  totalParticipants: number;
+  excludeHonoree?: boolean;
+}
+
+export interface BookingPricing {
+  packageBaseCents: number;
+  serviceFeeCents: number;
+  totalCents: number;
+  perPersonCents: number;
+  payingCount: number;
+  depositCents: number;
+  remainingCents: number;
+}
+
+/**
+ * Single source of truth for all booking pricing calculations.
+ * Used by bookingsRepository.calculateCosts() and useBookingFlow.
+ */
+export function calculateBookingPricing(input: PackagePricingInput): BookingPricing {
+  const { pricePerPersonCents, baseFeeCents = 0, totalParticipants, excludeHonoree = false } = input;
+
+  const payingCount = excludeHonoree ? Math.max(totalParticipants - 1, 1) : totalParticipants;
+  const packageBaseCents = (pricePerPersonCents * payingCount) + baseFeeCents;
+  const serviceFeeCents = Math.max(
+    Math.round(packageBaseCents * SERVICE_FEE_PERCENTAGE),
+    MIN_SERVICE_FEE_CENTS
+  );
+  const totalCents = packageBaseCents + serviceFeeCents;
+  const perPersonCents = payingCount > 0 ? Math.round(totalCents / payingCount) : totalCents;
+  const depositCents = Math.round(totalCents * 0.3); // 30% deposit
+  const remainingCents = totalCents - depositCents;
+
+  return {
+    packageBaseCents,
+    serviceFeeCents,
+    totalCents,
+    perPersonCents,
+    payingCount,
+    depositCents,
+    remainingCents,
+  };
+}
+```
+
+- [ ] **Step 2: Update `bookingsRepository.calculateCosts` to delegate**
+
+In `src/repositories/bookings.ts`, find the `calculateCosts` method. Replace its internal calculation:
+
+```typescript
+// ADD import at top of bookings.ts:
+import { calculateBookingPricing } from '@/utils/pricing';
+
+// REPLACE the calculateCosts method body:
+calculateCosts(pricePerPersonCents: number, totalParticipants: number, excludeHonoree = false) {
+  const baseFeeCents = 0; // packages use price_per_person_cents only
+  return calculateBookingPricing({
+    pricePerPersonCents,
+    baseFeeCents,
+    totalParticipants,
+    excludeHonoree,
+  });
+},
+```
+
+- [ ] **Step 3: Update `useBookingFlow.ts` pricing useMemo**
+
+Find the pricing `useMemo` in `src/hooks/useBookingFlow.ts`. Replace the inline calculation:
+
+```typescript
+// ADD import:
+import { calculateBookingPricing } from '@/utils/pricing';
+
+// REPLACE the pricing useMemo:
+const activePricing = useMemo(() => {
+  if (!activePkg || !totalParticipants) return null;
+  const pricePerPersonCents = activePkg.price_per_person_cents ?? 0;
+  const baseFeeCents = activePkg.base_price_cents ?? 0;
+  return calculateBookingPricing({
+    pricePerPersonCents,
+    baseFeeCents,
+    totalParticipants,
+    excludeHonoree: excludeHonoree ?? false,
+  });
+}, [activePkg, totalParticipants, excludeHonoree]);
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1 | tail -20
+```
+Expected: 0 errors related to pricing.ts changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/utils/pricing.ts src/repositories/bookings.ts src/hooks/useBookingFlow.ts
+git commit -m "refactor: consolidate pricing logic into canonical src/utils/pricing.ts"
+```
+
+---
+
+### Task 1.2: Fix `getProgressPercentage` — hardcoded `8` → `steps.length`
+
+**Files:**
+- Modify: `src/utils/planningProgress.ts`
+
+- [ ] **Step 1: Fix the hardcoded divisor**
+
+In `src/utils/planningProgress.ts` line 117, change:
+```typescript
+// BEFORE:
+return Math.round((completedCount / 8) * 100);
+
+// AFTER:
+return Math.round((completedCount / steps.length) * 100);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/utils/planningProgress.ts
+git commit -m "fix: getProgressPercentage uses steps.length instead of hardcoded 8"
+```
+
+---
+
+### Task 1.3: Type `useBookingFlow` Returns — Remove `any`
+
+**Files:**
+- Modify: `src/hooks/useBookingFlow.ts`
+
+- [ ] **Step 1: Add `FallbackPackage` type and replace `any` return types**
+
+At the top of `src/hooks/useBookingFlow.ts`, add/update the return type interface:
+
+```typescript
+// ADD after existing imports:
+import type { EventWithDetails } from '@/repositories/events';
+import type { ParticipantWithProfile } from '@/repositories/participants';
+import type { BookingWithDetails } from '@/repositories/bookings';
+import type { Database } from '@/lib/supabase/types';
+
+type Package = Database['public']['Tables']['packages']['Row'];
+
+// FallbackPackage matches the FALLBACK_PKG record shape
+export interface FallbackPackage {
+  id: string;
+  name: string;
+  tier: string;
+  price_per_person_cents: number;
+  base_price_cents: 0;
+  slug: string;
+  [key: string]: unknown;
+}
+
+export interface UseBookingFlowResult {
+  event: EventWithDetails | null | undefined;
+  participants: ParticipantWithProfile[];
+  booking: BookingWithDetails | null | undefined;
+  package: Package | FallbackPackage | null | undefined;
+  // ... keep all other existing fields
+}
+```
+
+- [ ] **Step 2: Replace `any` casts in the hook's return value**
+
+Find all `event: any`, `participants: any[]`, `booking: any`, `package: any` in the `UseBookingFlowResult` interface and replace with the typed versions from Step 1.
+
+- [ ] **Step 3: TypeScript check**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1 | grep -E "useBookingFlow|error" | head -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/hooks/useBookingFlow.ts
+git commit -m "fix: type useBookingFlow return shape — replace any with proper types"
+```
+
+---
+
+### Task 1.4: Fix Auth Subscription Leak in `_layout.tsx`
+
+**Files:**
+- Modify: `app/_layout.tsx`
+
+- [ ] **Step 1: Fix the async cleanup in useEffect**
+
+In `app/_layout.tsx`, find the `useEffect` that calls `initialize()`. The current pattern ignores the cleanup Promise. Replace:
+
+```typescript
+// BEFORE (approximately):
+useEffect(() => {
+  initialize();
+  // ...
+}, [initialize]);
+
+// AFTER — properly await the cleanup function:
+useEffect(() => {
+  let cleanup: (() => void) | undefined;
+  initialize().then((fn) => {
+    if (typeof fn === 'function') cleanup = fn;
+  });
+  return () => {
+    cleanup?.();
+  };
+}, []); // empty deps — initialize is stable (Zustand action)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/_layout.tsx
+git commit -m "fix: properly await and invoke auth subscription cleanup in root layout"
+```
+
+---
+
+### Task 1.5: Remove Module-Level `autoSaveTimer` Singleton
+
+**Files:**
+- Modify: `src/stores/wizardStore.ts`
+
+- [ ] **Step 1: Remove the module-level timer and dead actions**
+
+In `src/stores/wizardStore.ts`:
+
+1. Remove the module-level `let autoSaveTimer: ...` declaration (around line 18-19)
+2. Remove the `startAutoSave` action from the store
+3. Remove the `stopAutoSave` action from the store
+4. The `useWizardAutoSave` hook (already in the file) is the correct pattern — keep it
+
+- [ ] **Step 2: Find all callers of `startAutoSave`/`stopAutoSave` and remove them**
+
+```bash
+grep -r "startAutoSave\|stopAutoSave" /Users/soleilphoenix/Desktop/GameOver-quality-fixes/app /Users/soleilphoenix/Desktop/GameOver-quality-fixes/src --include="*.tsx" --include="*.ts" -l
+```
+
+For each file found, remove the `startAutoSave()`/`stopAutoSave()` calls. The `useWizardAutoSave()` hook handles this automatically when wizard screens mount.
+
+- [ ] **Step 3: Update the TypeScript interface for the wizard store if it declares these methods**
+
+Remove `startAutoSave` and `stopAutoSave` from `WizardStore` interface if present.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1 | tail -20
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/stores/wizardStore.ts
+git commit -m "refactor: remove module-level autoSaveTimer singleton — use useWizardAutoSave hook only"
+```
+
+---
+
+### Task 1.6: Add Screen-Level Error Boundaries
+
+**Files:**
+- Create: `src/components/ErrorBoundary.tsx`
+- Modify: `app/_layout.tsx`
+- Modify: `app/(tabs)/_layout.tsx`
+
+- [ ] **Step 1: Create reusable ErrorBoundary component**
+
+```typescript
+// src/components/ErrorBoundary.tsx
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { DARK_THEME } from '@/constants/theme';
+
+interface Props {
+  children: React.ReactNode;
+  fallbackTitle?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // TODO: send to Sentry when integrated
+    console.error('[ErrorBoundary]', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.title}>
+            {this.props.fallbackTitle ?? 'Something went wrong'}
+          </Text>
+          <Text style={styles.subtitle}>
+            {this.state.error?.message ?? 'An unexpected error occurred.'}
+          </Text>
+          <Pressable
+            style={styles.button}
+            onPress={() => this.setState({ hasError: false, error: undefined })}
+          >
+            <Text style={styles.buttonText}>Try Again</Text>
+          </Pressable>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: DARK_THEME.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    color: DARK_THEME.textPrimary,
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: DARK_THEME.textSecondary,
+    fontSize: 14,
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  button: {
+    backgroundColor: DARK_THEME.primary,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+```
+
+- [ ] **Step 2: Wrap tab screens in ErrorBoundary**
+
+In `app/(tabs)/_layout.tsx`, wrap the `<Tabs>` component:
+
+```typescript
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+
+// Wrap the return value:
+return (
+  <ErrorBoundary fallbackTitle="Tab Error">
+    <Tabs ...>
+      {/* existing content */}
+    </Tabs>
+  </ErrorBoundary>
+);
+```
+
+- [ ] **Step 3: TypeScript check**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/components/ErrorBoundary.tsx app/(tabs)/_layout.tsx
+git commit -m "feat: add ErrorBoundary component with retry — wrap tab navigator"
+```
+
+---
+
+### Task 1.7: Phase 1 TypeScript Verification
+
+- [ ] **Run full typecheck**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1
+```
+Expected: 0 errors introduced by Phase 1 changes.
+
+---
+
+## PHASE 2: Code Reviewer Fixes
+
+### Task 2.1: Add Schema Validation on AsyncStorage Reads in `useUrgentPayment`
+
+**Why:** `JSON.parse` on corrupted storage silently misrepresents payment state. A user who paid can be shown as unpaid.
+
+**Files:**
+- Modify: `src/hooks/useUrgentPayment.ts`
+
+- [ ] **Step 1: Add a type guard for BudgetInfo**
+
+```typescript
+// In src/hooks/useUrgentPayment.ts, add after imports:
+
+interface BudgetInfo {
+  paidAmountCents: number;
+  totalCents: number;
+  perPersonCents?: number;
+  payingCount?: number;
+}
+
+function isValidBudgetInfo(val: unknown): val is BudgetInfo {
+  if (!val || typeof val !== 'object') return false;
+  const obj = val as Record<string, unknown>;
+  return typeof obj.paidAmountCents === 'number' && typeof obj.totalCents === 'number';
+}
+
+function isValidBudgetInfoMap(val: unknown): val is Record<string, BudgetInfo> {
+  if (!val || typeof val !== 'object') return false;
+  return Object.values(val as object).every(isValidBudgetInfo);
+}
+```
+
+- [ ] **Step 2: Apply validation on the AsyncStorage reads**
+
+```typescript
+// REPLACE the budget info useEffect:
+useEffect(() => {
+  AsyncStorage.getItem('budget_info')
+    .then(raw => {
+      if (!raw) return;
+      try {
+        const parsed = JSON.parse(raw);
+        if (isValidBudgetInfoMap(parsed)) {
+          setBudgetInfos(parsed);
+        } else {
+          console.warn('[useUrgentPayment] budget_info cache invalid schema, skipping');
+        }
+      } catch {
+        console.warn('[useUrgentPayment] budget_info cache parse error');
+      }
+    })
+    .catch(() => {});
+}, [events]);
+
+// REPLACE the seen events useEffect:
+useEffect(() => {
+  AsyncStorage.getItem(URGENT_SEEN_KEY)
+    .then(raw => {
+      if (!raw) return;
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.every(id => typeof id === 'string')) {
+          setSeenEventIds(new Set(parsed));
+        }
+      } catch {
+        console.warn('[useUrgentPayment] urgent seen key parse error');
+      }
+    })
+    .catch(() => {});
+}, []);
+```
+
+- [ ] **Step 3: Update `budgetInfos` state type**
+
+```typescript
+// CHANGE:
+const [budgetInfos, setBudgetInfos] = useState<Record<string, any>>({});
+// TO:
+const [budgetInfos, setBudgetInfos] = useState<Record<string, BudgetInfo>>({});
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/hooks/useUrgentPayment.ts
+git commit -m "fix: validate AsyncStorage JSON parse in useUrgentPayment — prevent silent payment state corruption"
+```
+
+---
+
+### Task 2.2: Fix Raw Supabase Calls — Invite Codes in Budget Screen
+
+**Why:** `budget/index.tsx` calls `supabase` directly, bypassing the repository/React Query layer. This violates the architecture rule and has no error handling.
+
+**Files:**
+- Modify: `src/repositories/invites.ts` (add `getGuestsByEventId`)
+- Modify: `src/hooks/queries/useInvites.ts` (add `useInviteGuests` hook)
+- Modify: `app/(tabs)/budget/index.tsx` (replace raw call with hook)
+
+- [ ] **Step 1: Add `getGuestsByEventId` to invites repository**
+
+In `src/repositories/invites.ts`, add:
+
+```typescript
+async getGuestsByEventId(eventId: string): Promise<Array<{
+  id: string;
+  guest_first_name: string | null;
+  guest_last_name: string | null;
+  guest_email: string | null;
+}>> {
+  const { data, error } = await supabase
+    .from('invite_codes')
+    .select('id, guest_first_name, guest_last_name, guest_email')
+    .eq('event_id', eventId);
+
+  if (error) {
+    console.warn('[invitesRepository.getGuestsByEventId]', error.message);
+    return [];
+  }
+  return data ?? [];
+},
+```
+
+- [ ] **Step 2: Add `useInviteGuests` hook in `src/hooks/queries/useInvites.ts`**
+
+```typescript
+export function useInviteGuests(eventId: string | null) {
+  return useQuery({
+    queryKey: inviteKeys.guests(eventId ?? ''),
+    queryFn: () => invitesRepository.getGuestsByEventId(eventId!),
+    enabled: !!eventId,
+    staleTime: 60 * 1000,
+  });
+}
+```
+
+Also add to `inviteKeys`:
+```typescript
+guests: (eventId: string) => [...inviteKeys.all, 'guests', eventId] as const,
+```
+
+- [ ] **Step 3: Replace raw Supabase call in `budget/index.tsx`**
+
+Find the `supabase.from('invite_codes').select(...)` block in `budget/index.tsx`.
+Replace it by calling `useInviteGuests(selectedEventId)` at the top of the component:
+
+```typescript
+// ADD at top of BudgetScreen component:
+const { data: inviteCodeGuests = [] } = useInviteGuests(selectedEventId);
+```
+
+Remove the local `inviteCodeGuests` useState + the raw supabase call effect.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/repositories/invites.ts src/hooks/queries/useInvites.ts app/(tabs)/budget/index.tsx
+git commit -m "fix: replace raw Supabase call in budget screen with useInviteGuests hook"
+```
+
+---
+
+### Task 2.3: Fix Raw Supabase Calls in `participants.tsx`
+
+**Files:**
+- Modify: `app/event/[id]/participants.tsx`
+
+- [ ] **Step 1: Replace inline supabase call with existing repository method**
+
+In `app/event/[id]/participants.tsx`, find the raw `supabase.from('invite_codes').select(...)` call (lines ~136-156). This data is already available via `useInviteGuests(eventId)` added in Task 2.2. Replace the raw call with that hook:
+
+```typescript
+// ADD import:
+import { useInviteGuests } from '@/hooks/queries/useInvites';
+
+// At component top, ADD:
+const { data: inviteCodeGuests = [] } = useInviteGuests(id ?? null);
+
+// REMOVE: the raw supabase call and its useState
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/event/[id]/participants.tsx
+git commit -m "fix: replace raw Supabase call in participants screen with useInviteGuests hook"
+```
+
+---
+
+### Task 2.4: Fix Swallowed Profile Errors in `participants.ts`
+
+**Files:**
+- Modify: `src/repositories/participants.ts`
+
+- [ ] **Step 1: Surface profile fetch errors**
+
+Find the profiles query in `getByEventId` where `error` is destructured but ignored:
+
+```typescript
+// BEFORE:
+const { data: profilesData } = await supabase.from('profiles').select(...);
+
+// AFTER:
+const { data: profilesData, error: profilesError } = await supabase.from('profiles').select(...).in('id', userIds);
+if (profilesError) {
+  console.warn('[participantsRepository.getByEventId] profiles fetch failed:', profilesError.message);
+  // Continue — participants render without profile data rather than crashing
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/repositories/participants.ts
+git commit -m "fix: log profile fetch errors in participantsRepository instead of silently swallowing"
+```
+
+---
+
+### Task 2.5: Fix `emailBlurTimerRef` Unmount Leak in `participants.tsx`
+
+**Files:**
+- Modify: `app/event/[id]/participants.tsx`
+
+- [ ] **Step 1: Add cleanup for the blur debounce timer**
+
+Find where `emailBlurTimerRef` is used. Add a `useEffect` cleanup:
+
+```typescript
+// ADD this useEffect inside the component:
+useEffect(() => {
+  return () => {
+    if (emailBlurTimerRef.current) {
+      clearTimeout(emailBlurTimerRef.current);
+    }
+  };
+}, []);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/event/[id]/participants.tsx
+git commit -m "fix: clear emailBlurTimerRef on unmount to prevent setState on unmounted component"
+```
+
+---
+
+### Task 2.6: Fix Nullish Coalescing in `invites.ts` — `|| 7` → `?? 7`
+
+**Files:**
+- Modify: `src/repositories/invites.ts`
+
+- [ ] **Step 1: Fix the falsy `0` bug**
+
+Find in `invites.ts`:
+```typescript
+// BEFORE:
+expiresAt.setDate(expiresAt.getDate() + (options?.expiresInDays || 7));
+
+// AFTER:
+expiresAt.setDate(expiresAt.getDate() + (options?.expiresInDays ?? 7));
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add src/repositories/invites.ts
+git commit -m "fix: use nullish coalescing for expiresInDays default (|| → ??) to handle 0 correctly"
+```
+
+---
+
+### Task 2.7: Fix `(booking as any)` Casts in Event Detail
+
+**Files:**
+- Modify: `app/event/[id]/index.tsx`
+
+- [ ] **Step 1: Extend `BookingWithDetails` type or use the proper fields**
+
+The fields `paying_participants` and `exclude_honoree` are actual booking fields. Add them to the type in `src/repositories/bookings.ts` if missing, or check that they're in the DB type. Then remove the `(booking as any)` casts in `event/[id]/index.tsx` and access the fields directly.
+
+```typescript
+// BEFORE (4 occurrences):
+(booking as any).paying_participants
+(booking as any).exclude_honoree
+
+// AFTER (once you verify these fields exist in BookingWithDetails or Booking type):
+booking?.paying_participants
+booking?.exclude_honoree
+```
+
+If the fields aren't in the type, extend `BookingWithDetails`:
+```typescript
+export interface BookingWithDetails extends Booking {
+  package: Package | null;
+  event: { id: string; title: string; honoree_name: string; } | null;
+  paying_participants?: number; // if not auto-generated from DB type
+  exclude_honoree?: boolean;    // if not auto-generated from DB type
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/event/[id]/index.tsx src/repositories/bookings.ts
+git commit -m "fix: remove (booking as any) casts — use typed fields directly"
+```
+
+---
+
+### Task 2.8: Fix Hardcoded English Strings in Event Detail
+
+**Files:**
+- Modify: `app/event/[id]/index.tsx`
+- Modify: `src/i18n/en.ts`
+- Modify: `src/i18n/de.ts`
+
+- [ ] **Step 1: Add missing i18n keys**
+
+In `src/i18n/en.ts`, add to the `events` section (or create a new `eventDetail` section):
+```typescript
+eventDetail: {
+  bookPackage: 'Book Package',
+  yourContribution: 'Your Contribution',
+  gotIt: 'Got it',
+},
+```
+
+In `src/i18n/de.ts`:
+```typescript
+eventDetail: {
+  bookPackage: 'Paket buchen',
+  yourContribution: 'Dein Beitrag',
+  gotIt: 'Verstanden',
+},
+```
+
+- [ ] **Step 2: Replace hardcoded strings in `event/[id]/index.tsx`**
+
+```typescript
+// Replace 'Book Package' with t.eventDetail.bookPackage
+// Replace 'Your Contribution' with t.eventDetail.yourContribution
+// Replace 'Got it' with t.eventDetail.gotIt
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/event/[id]/index.tsx src/i18n/en.ts src/i18n/de.ts
+git commit -m "fix: replace hardcoded English strings in event detail with i18n keys"
+```
+
+---
+
+### Task 2.9: Fix `handleGenerateInvite` Unhandled Promise
+
+**Files:**
+- Modify: `app/event/[id]/index.tsx`
+
+- [ ] **Step 1: Add try/catch to the generate invite handler**
+
+Find `handleGenerateInvite` in `event/[id]/index.tsx`. Wrap in try/catch:
+
+```typescript
+const handleGenerateInvite = async (): Promise<string> => {
+  try {
+    const invite = await createInvite.mutateAsync({ eventId: id! });
+    return invite.code;
+  } catch (error) {
+    console.error('[handleGenerateInvite] failed:', error);
+    // Return empty string so callers can detect failure
+    return '';
+  }
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/event/[id]/index.tsx
+git commit -m "fix: add try/catch to handleGenerateInvite to prevent unhandled promise rejection"
+```
+
+---
+
+### Task 2.10: Phase 2 TypeScript Verification
+
+- [ ] **Run full typecheck**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1
+```
+Expected: 0 errors from Phase 2 changes.
+
+---
+
+## PHASE 3: Security Engineer Fixes
+
+### Task 3.1: Replace ngrok URL in `send-guest-invitations` (CRITICAL — Pre-Launch)
+
+**Files:**
+- Modify: `supabase/functions/send-guest-invitations/index.ts`
+
+- [ ] **Step 1: Replace hardcoded ngrok URL with production URL**
+
+Find in `supabase/functions/send-guest-invitations/index.ts` (around line 349):
+```typescript
+// BEFORE:
+const inviteUrl = `https://realestate-delisa-statesmanlike.ngrok-free.dev/invite/${code}`;
+
+// AFTER:
+const appBaseUrl = Deno.env.get('APP_BASE_URL') ?? 'https://game-over.app';
+const inviteUrl = `${appBaseUrl}/invite/${code}`;
+```
+
+Set the env variable in Supabase dashboard: `APP_BASE_URL=https://game-over.app`
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/functions/send-guest-invitations/index.ts
+git commit -m "fix(security): replace hardcoded ngrok URL with APP_BASE_URL env var in guest invitations"
+```
+
+---
+
+### Task 3.2: Add Authentication to `send-guest-invitations` (CRITICAL)
+
+**Files:**
+- Modify: `supabase/functions/send-guest-invitations/index.ts`
+
+- [ ] **Step 1: Add auth verification at the top of the handler**
+
+In `supabase/functions/send-guest-invitations/index.ts`, after the CORS preflight check, add:
+
+```typescript
+// After cors preflight block, before reading request body:
+
+// Verify caller is authenticated and owns the event
+const authHeader = req.headers.get('Authorization');
+if (!authHeader?.startsWith('Bearer ')) {
+  return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+    status: 401,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+const userToken = authHeader.replace('Bearer ', '');
+
+// Create a USER-scoped client (not service role) to verify the token
+const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.39.3');
+const userSupabase = createClient(
+  Deno.env.get('SUPABASE_URL')!,
+  Deno.env.get('SUPABASE_ANON_KEY')!,
+  { global: { headers: { Authorization: `Bearer ${userToken}` } } }
+);
+
+const { data: { user }, error: authError } = await userSupabase.auth.getUser();
+if (authError || !user) {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 2: Add ownership verification after reading `eventId`**
+
+After `const { eventId, ... } = await req.json()`, add:
+
+```typescript
+// Verify caller owns the event (use service-role client for this check)
+const { data: eventCheck, error: eventCheckError } = await supabase
+  .from('events')
+  .select('id, created_by')
+  .eq('id', eventId)
+  .single();
+
+if (eventCheckError || !eventCheck) {
+  return new Response(JSON.stringify({ error: 'Event not found' }), {
+    status: 404,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+if (eventCheck.created_by !== user.id) {
+  return new Response(JSON.stringify({ error: 'Forbidden — not event owner' }), {
+    status: 403,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 3: Add batch size guard**
+
+After extracting `guests` from the request body, add:
+
+```typescript
+const MAX_GUESTS_PER_CALL = 50;
+if (guests.length > MAX_GUESTS_PER_CALL) {
+  return new Response(JSON.stringify({
+    error: `Too many guests. Maximum ${MAX_GUESTS_PER_CALL} per call. Paginate your requests.`
+  }), {
+    status: 400,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/functions/send-guest-invitations/index.ts
+git commit -m "fix(security): add JWT auth + event ownership verification to send-guest-invitations"
+```
+
+---
+
+### Task 3.3: Add Authentication to `send-push-notification`
+
+**Files:**
+- Modify: `supabase/functions/send-push-notification/index.ts`
+
+- [ ] **Step 1: Add service-role or JWT auth check**
+
+`send-push-notification` is intended to be called internally (from other edge functions), not from the client. Add a service-role secret check:
+
+```typescript
+// At the top of the handler, after CORS preflight:
+const authHeader = req.headers.get('Authorization');
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+// Allow either service-role key or valid user JWT
+if (!authHeader) {
+  return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
+    status: 401,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+// For internal calls from other edge functions, accept service role key
+if (authHeader !== `Bearer ${serviceRoleKey}`) {
+  // Otherwise verify as user JWT
+  const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.39.3');
+  const userSupabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: authHeader } } }
+  );
+  const { error: authError } = await userSupabase.auth.getUser();
+  if (authError) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/functions/send-push-notification/index.ts
+git commit -m "fix(security): add authorization check to send-push-notification edge function"
+```
+
+---
+
+### Task 3.4: Add Authentication to `send-final-briefing` + Fix Missing try/catch
+
+**Files:**
+- Modify: `supabase/functions/send-final-briefing/index.ts`
+
+- [ ] **Step 1: Add cron secret authentication**
+
+`send-final-briefing` is triggered by pg_cron. Protect it with a cron secret:
+
+```typescript
+// At top of handler:
+const authHeader = req.headers.get('Authorization');
+const cronSecret = Deno.env.get('CRON_SECRET');
+
+if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+```
+
+Set `CRON_SECRET` env var in Supabase dashboard. Update the pg_cron SQL to pass it:
+```sql
+-- Update the cron job to include the auth header
+SELECT cron.schedule('send-final-briefing-daily', '0 9 * * *',
+  $$SELECT net.http_post(
+    url := current_setting('app.settings.supabase_url') || '/functions/v1/send-final-briefing',
+    headers := '{"Authorization": "Bearer ' || current_setting('app.settings.cron_secret') || '", "Content-Type": "application/json"}'::jsonb,
+    body := '{}'::jsonb
+  )$$
+);
+```
+
+- [ ] **Step 2: Add missing outer try/catch**
+
+Wrap the entire handler body in try/catch:
+
+```typescript
+serve(async (req: Request) => {
+  try {
+    // ... all existing logic ...
+  } catch (error) {
+    console.error('[send-final-briefing] Unhandled error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/functions/send-final-briefing/index.ts
+git commit -m "fix(security): add cron secret auth + outer try/catch to send-final-briefing"
+```
+
+---
+
+### Task 3.5: Add Authentication to `send-email`
+
+**Files:**
+- Modify: `supabase/functions/send-email/index.ts`
+
+- [ ] **Step 1: Add service-role-only auth**
+
+`send-email` is internal-only (called from stripe-webhook, process-payment-reminders). Add service-role check:
+
+```typescript
+// At top of handler:
+const authHeader = req.headers.get('Authorization');
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+if (!authHeader || authHeader !== `Bearer ${serviceRoleKey}`) {
+  return new Response(JSON.stringify({ error: 'Unauthorized — internal function' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/functions/send-email/index.ts
+git commit -m "fix(security): restrict send-email to service-role callers only"
+```
+
+---
+
+### Task 3.6: Fix `event_participants` RLS SELECT Policy
+
+**Files:**
+- Create: `supabase/migrations/20260320000000_restore_participant_rls_select.sql`
+
+- [ ] **Step 1: Create the migration**
+
+```sql
+-- supabase/migrations/20260320000000_restore_participant_rls_select.sql
+-- Restore scoped RLS on event_participants SELECT.
+-- The USING (true) policy (from 20260205000003) exposed ALL participant data
+-- to ALL authenticated users. The SECURITY DEFINER helper functions from
+-- 20260211000001 already exist and break the RLS recursion cycle.
+
+-- Drop the permissive open policy
+DROP POLICY IF EXISTS "Authenticated users can view event participants" ON event_participants;
+
+-- Restore scoped access using the existing SECURITY DEFINER helpers
+-- These functions bypass the outer RLS check, preventing recursion.
+CREATE POLICY "Participants and creators can view event participants"
+  ON event_participants FOR SELECT TO authenticated
+  USING (
+    public.is_event_creator(event_id)
+    OR public.is_event_participant(event_id)
+  );
+```
+
+- [ ] **Step 2: Apply migration locally if Supabase CLI is available**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+npx supabase db push --dry-run 2>&1 || echo "Apply via Supabase dashboard SQL editor if CLI not linked"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/migrations/20260320000000_restore_participant_rls_select.sql
+git commit -m "fix(security): restore scoped RLS SELECT on event_participants using SECURITY DEFINER helpers"
+```
+
+---
+
+### Task 3.7: Add Avatar Upload Validation in `invite/[code].tsx`
+
+**Files:**
+- Modify: `app/invite/[code].tsx`
+
+- [ ] **Step 1: Add MIME type and size validation before upload**
+
+Find the avatar upload section in `app/invite/[code].tsx`. Before the `supabase.storage.from('avatars').upload(...)` call, add:
+
+```typescript
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// Validate blob before upload
+if (!ALLOWED_MIME_TYPES.includes(blob.type)) {
+  Alert.alert('Invalid file', 'Please select a JPEG, PNG, or WebP image.');
+  return;
+}
+if (blob.size > MAX_FILE_SIZE_BYTES) {
+  Alert.alert('File too large', 'Please select an image under 5 MB.');
+  return;
+}
+
+// Use MIME type for extension instead of URI string parsing
+const mimeToExt: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+const ext = mimeToExt[blob.type] ?? 'jpg';
+const path = `avatars/${currentUser.id}.${ext}`;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add app/invite/[code].tsx
+git commit -m "fix(security): add MIME type and file size validation before avatar upload"
+```
+
+---
+
+### Task 3.8: Add Currency Allowlist in `create-payment-intent`
+
+**Files:**
+- Modify: `supabase/functions/create-payment-intent/index.ts`
+
+- [ ] **Step 1: Add currency validation**
+
+Find where `currency` is extracted from the request. Add:
+
+```typescript
+const ALLOWED_CURRENCIES = ['eur', 'usd', 'gbp', 'chf'];
+const normalizedCurrency = (currency ?? 'eur').toLowerCase();
+
+if (!ALLOWED_CURRENCIES.includes(normalizedCurrency)) {
+  return new Response(JSON.stringify({
+    success: false,
+    error: `Unsupported currency. Allowed: ${ALLOWED_CURRENCIES.join(', ')}`
+  }), {
+    status: 400,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 2: Use `normalizedCurrency` in the Stripe PaymentIntent creation**
+
+Replace any subsequent `currency` usage with `normalizedCurrency`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes
+git add supabase/functions/create-payment-intent/index.ts
+git commit -m "fix(security): validate currency against allowlist in create-payment-intent"
+```
+
+---
+
+### Task 3.9: Phase 3 Final TypeScript Verification
+
+- [ ] **Run full typecheck**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1
+```
+Expected: 0 TypeScript errors across all three phases.
+
+- [ ] **Run linter**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run lint 2>&1 | grep -E "error|warning" | head -30
+```
+
+---
+
+## Final Verification & PR
+
+- [ ] **Run full typecheck one last time**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && npm run typecheck 2>&1
+```
+
+- [ ] **Check git log for all commits**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && git log --oneline main..HEAD
+```
+
+- [ ] **Push branch**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver-quality-fixes && git push -u origin fix/tier1-quality-and-security
+```
+
+- [ ] **Create PR via GitHub CLI**
+
+```bash
+gh pr create \
+  --title "fix: Tier 1 quality & security fixes — Architect, Code Reviewer, Security Engineer" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements all critical/high/medium findings from the Tier 1 agent analysis (Software Architect, Code Reviewer, Security Engineer).
+
+### Phase 1 — Architecture (Software Architect)
+- Consolidated pricing logic into `src/utils/pricing.ts` (single source of truth)
+- Fixed `getProgressPercentage` hardcoded `8` → `steps.length`
+- Typed `useBookingFlow` returns (removed `any`)
+- Fixed auth subscription cleanup in root layout
+- Removed module-level `autoSaveTimer` singleton
+- Added `ErrorBoundary` component + wrapped tab navigator
+
+### Phase 2 — Code Quality (Code Reviewer)
+- Added schema validation on `AsyncStorage` JSON reads in `useUrgentPayment`
+- Replaced raw Supabase calls in budget/participants screens with `useInviteGuests` hook
+- Fixed swallowed profile fetch errors in `participantsRepository`
+- Added `emailBlurTimerRef` unmount cleanup
+- Fixed `|| 7` → `?? 7` for invite expiry
+- Removed `(booking as any)` casts in event detail
+- Added i18n for hardcoded English strings
+- Wrapped `handleGenerateInvite` in try/catch
+
+### Phase 3 — Security (Security Engineer)
+- Replaced hardcoded ngrok URL with `APP_BASE_URL` env var
+- Added JWT auth + event ownership check to `send-guest-invitations`
+- Added 50-guest batch size limit to `send-guest-invitations`
+- Added auth to `send-push-notification`, `send-final-briefing`, `send-email`
+- Restored scoped RLS on `event_participants` SELECT (via new migration)
+- Added MIME type + size validation on avatar upload
+- Added currency allowlist validation in `create-payment-intent`
+
+## Test plan
+- [ ] `npm run typecheck` passes with 0 errors
+- [ ] `npm run lint` passes
+- [ ] Auth flows (signup, login, social) work in Expo Go
+- [ ] Event creation wizard completes end-to-end
+- [ ] Booking + payment flow works
+- [ ] Guest invite acceptance flow works
+- [ ] Budget screen loads without errors
+- [ ] Edge functions: verify `send-guest-invitations` returns 401 without auth header
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Post-Merge: Supabase Dashboard Actions Required
+
+The following must be done manually in the Supabase dashboard after merging:
+
+1. **Apply migration** `20260320000000_restore_participant_rls_select.sql` via SQL Editor
+2. **Set env vars** on edge functions:
+   - `send-guest-invitations`: `APP_BASE_URL=https://game-over.app`
+   - `send-final-briefing`: `CRON_SECRET=<generate secure random string>`
+3. **Update pg_cron job** for `send-final-briefing` to pass `Authorization: Bearer <CRON_SECRET>` header
+4. **Enable email confirmation** in Supabase Auth settings (currently disabled — security risk)

--- a/game-over-app/docs/superpowers/plans/2026-03-21-tier2-backend-security.md
+++ b/game-over-app/docs/superpowers/plans/2026-03-21-tier2-backend-security.md
@@ -1,0 +1,377 @@
+# Tier 2 Backend & Security Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the critical payment bypass vulnerability, make the Stripe webhook idempotent, add missing database indexes, and add financial integrity constraints.
+
+**Architecture:** All changes are isolated — edge function fixes (Deno, no npm), new SQL migrations (applied via Supabase dashboard), and one app.config.ts line fix. No React component changes in this plan.
+
+**Tech Stack:** Deno Edge Functions (Stripe, Supabase), PostgreSQL migrations, TypeScript
+
+**Worktree:** Run in main repo at `/Users/soleilphoenix/Desktop/GameOver/game-over-app/`
+**Verify command:** `npm run typecheck 2>&1 | grep "error TS" | grep -v tsconfig`
+
+---
+
+## PHASE 1: Critical — Payment Amount Bypass
+
+### Task 1.1: Fix `create-payment-intent` — server-side amount calculation
+
+**Why:** The function currently uses `amount_cents` from the client request directly in `stripe.paymentIntents.create({ amount: amount_cents })`. An attacker can send `{ booking_id: "xxx", amount_cents: 1 }` to pay €0.01 for any booking.
+
+**Files:**
+- Modify: `supabase/functions/create-payment-intent/index.ts`
+
+**Current broken code (line 156):**
+```typescript
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: amount_cents,  // ← client-controlled value
+  ...
+});
+```
+
+**Root cause:** The booking is already fetched from DB (line 96–107) with `total_amount_cents`. The fix ignores the client value and computes the correct amount server-side.
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat /Users/soleilphoenix/Desktop/GameOver/game-over-app/supabase/functions/create-payment-intent/index.ts | head -120
+```
+
+- [ ] **Step 2: Update the booking SELECT query to include payment fields**
+
+The `booking` select at line 96 fetches `*`, which includes `total_amount_cents`, `deposit_amount_cents`, `payment_status`. Verify these are present. Then replace the `CreatePaymentIntentRequest` interface and the amount logic:
+
+```typescript
+// REPLACE the interface (around line 15):
+interface CreatePaymentIntentRequest {
+  booking_id: string;
+  payment_type?: 'deposit' | 'remaining' | 'full'; // client hints what they're paying
+  currency?: string;
+  // NOTE: amount_cents is intentionally NOT accepted from the client.
+  // The server computes the correct amount from the DB booking record.
+}
+```
+
+- [ ] **Step 3: Add server-side amount calculation after the booking ownership check**
+
+After line 112 (`if (booking.event.created_by !== user.id)`), add:
+
+```typescript
+// Parse payment_type from client (default 'full')
+const { booking_id, payment_type = 'full', currency }: CreatePaymentIntentRequest = await req.json();
+
+// --- SERVER-SIDE AMOUNT CALCULATION ---
+// NEVER trust amount_cents from the client. Compute from DB.
+const bookingTotalCents: number = booking.total_amount_cents ?? 0;
+const depositPaidCents: number = booking.deposit_amount_cents ?? 0;
+
+let serverAmountCents: number;
+if (payment_type === 'deposit') {
+  // 30% deposit
+  serverAmountCents = Math.round(bookingTotalCents * 0.3);
+} else if (payment_type === 'remaining') {
+  // Remaining balance after deposit
+  serverAmountCents = bookingTotalCents - depositPaidCents;
+} else {
+  // Full payment
+  serverAmountCents = bookingTotalCents;
+}
+
+if (serverAmountCents <= 0) {
+  return new Response(JSON.stringify({ success: false, error: 'Nothing to pay — booking may already be settled.' }), {
+    status: 400,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+const MAX_AMOUNT_CENTS = 10_000_000; // €100,000 hard cap
+if (serverAmountCents > MAX_AMOUNT_CENTS) {
+  return new Response(JSON.stringify({ success: false, error: 'Amount exceeds maximum allowed.' }), {
+    status: 400,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 4: Replace `amount: amount_cents` with `amount: serverAmountCents` in the PaymentIntent creation**
+
+Find the `stripe.paymentIntents.create` call (around line 155). Replace:
+```typescript
+// BEFORE:
+amount: amount_cents,
+
+// AFTER:
+amount: serverAmountCents,
+```
+
+Also update the audit log entry:
+```typescript
+// BEFORE:
+amount_cents: amount_cents,
+
+// AFTER:
+amount_cents: serverAmountCents,
+payment_type: payment_type,
+```
+
+- [ ] **Step 5: Remove the old `amount_cents` validation block (lines 72–80)**
+
+The old validation (`if (!amount_cents || amount_cents <= 0)` and the max check) is now replaced by server-side logic. Remove those lines.
+
+- [ ] **Step 6: Update the booking SELECT to include `total_amount_cents` and `deposit_amount_cents` explicitly**
+
+```typescript
+// Change the select from:
+.select(`*, event:events!inner(id, created_by, title, honoree_name)`)
+
+// To (explicit fields to make the type clear):
+.select(`id, total_amount_cents, deposit_amount_cents, payment_status, stripe_payment_intent_id, audit_log, event:events!inner(id, created_by, title, honoree_name)`)
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app
+git add supabase/functions/create-payment-intent/index.ts
+git commit -m "fix(security): compute payment amount server-side — reject client-provided amount_cents"
+```
+
+---
+
+## PHASE 2: High — Stripe Webhook Idempotency
+
+### Task 2.1: Make `handlePaymentSuccess` idempotent
+
+**Why:** Stripe retries webhooks on network errors. Without idempotency, each retry creates a duplicate `notifications.insert` and appends a duplicate audit log entry. The payment_status update is safe (idempotent by nature) but notifications pile up.
+
+**Files:**
+- Modify: `supabase/functions/stripe-webhook/index.ts`
+
+- [ ] **Step 1: Add idempotency guard in `handlePaymentSuccess`**
+
+In `handlePaymentSuccess`, after the audit log is fetched (around line 163), add this check before the `auditLog.push(...)`:
+
+```typescript
+// --- IDEMPOTENCY GUARD ---
+// Stripe retries webhooks. If we already processed this payment_intent, skip.
+const alreadyProcessed = auditLog.some(
+  (entry: { action: string; payment_intent_id?: string }) =>
+    entry.action === 'payment_succeeded' && entry.payment_intent_id === paymentIntent.id
+);
+if (alreadyProcessed) {
+  console.log(`[stripe-webhook] Duplicate event for PI ${paymentIntent.id} — skipping.`);
+  return;
+}
+```
+
+- [ ] **Step 2: Add idempotency guard in `handlePaymentFailure`**
+
+Same pattern, after the audit log is fetched in `handlePaymentFailure`:
+
+```typescript
+const alreadyProcessed = auditLog.some(
+  (entry: { action: string; payment_intent_id?: string }) =>
+    entry.action === 'payment_failed' && entry.payment_intent_id === paymentIntent.id
+);
+if (alreadyProcessed) {
+  console.log(`[stripe-webhook] Duplicate failure event for PI ${paymentIntent.id} — skipping.`);
+  return;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app
+git add supabase/functions/stripe-webhook/index.ts
+git commit -m "fix: make Stripe webhook idempotent — skip duplicate payment_intent events"
+```
+
+---
+
+## PHASE 3: High — Database Indexes
+
+### Task 3.1: Add missing performance indexes
+
+**Why:** The Database Optimizer agent identified 4 missing indexes that cause full table scans on every app start, guest filter, chat open, and notification bell fetch.
+
+**Files:**
+- Create: `supabase/migrations/20260321000000_performance_indexes.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- supabase/migrations/20260321000000_performance_indexes.sql
+-- Performance indexes identified by Database Optimizer analysis.
+-- All use CONCURRENTLY to avoid locking production tables during apply.
+-- Apply via: supabase db push OR Supabase SQL Editor.
+
+-- 1. Events by owner — hit on every app start (getByUser query)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_created_by_created_at
+  ON events (created_by, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- 2. Event participants by user + role — used by guest filter and invite acceptance
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_participants_user_role
+  ON event_participants (user_id, role);
+
+-- 3. Messages by channel — hit on every chat open
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_channel_created_at
+  ON messages (channel_id, created_at DESC);
+
+-- 4. Unread notifications — hit on every bell counter render
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notifications_user_unread
+  ON notifications (user_id, created_at DESC)
+  WHERE is_read = false;
+
+-- 5. Bookings by event — used by useBooking hook on every event detail open
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bookings_event_id
+  ON bookings (event_id);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app
+git add supabase/migrations/20260321000000_performance_indexes.sql
+git commit -m "perf(db): add 5 missing composite/partial indexes for events, participants, messages, notifications, bookings"
+```
+
+---
+
+## PHASE 4: Medium — Bookings Financial Integrity Constraints
+
+### Task 4.1: Add CHECK constraints to bookings table
+
+**Why:** Without DB-level constraints, a bug can insert a booking where `service_fee_cents + package_base_cents ≠ total_amount_cents`, or where `stripe_payment_intent_id` is duplicated across bookings. These constraints turn silent data corruption into loud errors.
+
+**Files:**
+- Create: `supabase/migrations/20260321000001_bookings_integrity_constraints.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- supabase/migrations/20260321000001_bookings_integrity_constraints.sql
+-- Financial integrity constraints for bookings table.
+-- These enforce that the DB never holds internally inconsistent payment data.
+
+-- Prevent duplicate payment intents (one PI → one booking)
+ALTER TABLE bookings
+  ADD CONSTRAINT bookings_stripe_pi_unique
+  UNIQUE (stripe_payment_intent_id)
+  DEFERRABLE INITIALLY DEFERRED;
+
+-- Total must be positive when set
+ALTER TABLE bookings
+  ADD CONSTRAINT bookings_total_positive
+  CHECK (total_amount_cents IS NULL OR total_amount_cents > 0);
+
+-- Deposit cannot exceed total
+ALTER TABLE bookings
+  ADD CONSTRAINT bookings_deposit_lte_total
+  CHECK (
+    deposit_amount_cents IS NULL
+    OR total_amount_cents IS NULL
+    OR deposit_amount_cents <= total_amount_cents
+  );
+
+-- Remaining cannot be negative
+ALTER TABLE bookings
+  ADD CONSTRAINT bookings_remaining_non_negative
+  CHECK (remaining_amount_cents IS NULL OR remaining_amount_cents >= 0);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app
+git add supabase/migrations/20260321000001_bookings_integrity_constraints.sql
+git commit -m "fix(db): add financial integrity constraints to bookings (unique PI, positive totals, deposit ≤ total)"
+```
+
+---
+
+## PHASE 5: High — Deep Link Domain Fix
+
+### Task 5.1: Fix `app.config.ts` domain mismatch
+
+**Why:** `applinks:gameover.app` is configured but the production domain is `game-over.app`. iOS Universal Links and Android App Links silently fail when the domain doesn't match — invite links from SMS/email won't open the app on real devices.
+
+**Files:**
+- Modify: `app.config.ts`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+grep -n "gameover.app\|game-over.app\|applinks\|intentFilters" /Users/soleilphoenix/Desktop/GameOver/game-over-app/app.config.ts
+```
+
+- [ ] **Step 2: Fix the domain reference**
+
+Find every occurrence of `gameover.app` (without hyphen) in `app.config.ts` and change to `game-over.app`. This affects:
+- `applinks:gameover.app` (iOS Associated Domains)
+- `android:host="gameover.app"` (Android Intent Filters)
+
+```typescript
+// BEFORE (iOS):
+associatedDomains: ['applinks:gameover.app'],
+
+// AFTER:
+associatedDomains: ['applinks:game-over.app'],
+
+// BEFORE (Android intentFilters):
+android: { host: 'gameover.app' }
+
+// AFTER:
+android: { host: 'game-over.app' }
+```
+
+- [ ] **Step 3: Verify no other domain references are wrong**
+
+```bash
+grep -rn "gameover\.app" /Users/soleilphoenix/Desktop/GameOver/game-over-app/app.config.ts
+```
+Expected: 0 results (all changed to `game-over.app`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app
+git add app.config.ts
+git commit -m "fix: correct deep link domain gameover.app → game-over.app in app.config.ts"
+```
+
+---
+
+## PHASE 6: Final Verification
+
+- [ ] **Step 1: TypeScript check**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app && npm run typecheck 2>&1 | grep "error TS" | grep -v tsconfig
+```
+Expected: 0 errors.
+
+- [ ] **Step 2: Confirm all migrations exist**
+
+```bash
+ls /Users/soleilphoenix/Desktop/GameOver/game-over-app/supabase/migrations/ | grep "20260321"
+```
+Expected: `20260321000000_performance_indexes.sql`, `20260321000001_bookings_integrity_constraints.sql`
+
+- [ ] **Step 3: Push to remote**
+
+```bash
+cd /Users/soleilphoenix/Desktop/GameOver/game-over-app && git push origin main
+```
+
+---
+
+## Post-Deploy: Supabase Dashboard Actions Required
+
+After pushing, apply in Supabase SQL Editor:
+1. `20260321000000_performance_indexes.sql` — run each `CREATE INDEX CONCURRENTLY` statement individually (CONCURRENTLY cannot run inside a transaction block)
+2. `20260321000001_bookings_integrity_constraints.sql` — run as a single statement block
+3. Verify `create-payment-intent` edge function: deploy updated version via `npx supabase functions deploy create-payment-intent`
+4. Verify `stripe-webhook` edge function: deploy via `npx supabase functions deploy stripe-webhook`

--- a/game-over-app/docs/superpowers/plans/2026-03-21-tier3-ux-design-fixes.md
+++ b/game-over-app/docs/superpowers/plans/2026-03-21-tier3-ux-design-fixes.md
@@ -1,0 +1,905 @@
+# Tier 3 — UX/Design Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all 22 Tier 3 UX/Design findings: 1 critical dark-theme visual bug, ~25 stale color references across 10 files, a guest invite login dead-end, fragile tab bar visibility logic, a shared IconCircle component extraction, and UX polish for Budget auto-select and Event Detail error states.
+
+**Architecture:** Fixes are grouped by scope — pure color/style changes first (no logic risk), then UX flow corrections, then design-system component extractions. Each task produces an independently testable change. The wizard step-progress indicator is already implemented and does NOT need to be added.
+
+**Tech Stack:** React Native, Expo Router, Tamagui, Zustand, TypeScript. All styling uses `DARK_THEME` from `src/constants/theme.ts` (`primary: '#5A7EB0'`).
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `app/event/[id]/polls.tsx` | Replace `colors.light.*` → `DARK_THEME.*` throughout |
+| `src/components/ui/GlassPanel.tsx` | `rgba(37,140,244,0.2)` → `rgba(90,126,176,0.2)` |
+| `src/components/ui/Badge.tsx` | `rgba(37,140,244,0.15)` → `rgba(90,126,176,0.15)` |
+| `src/constants/spacing.ts` | `shadowColor: '#258CF4'` → `'#5A7EB0'` |
+| `src/hooks/usePushNotifications.ts` | `lightColor: '#258CF4'` → `'#5A7EB0'` |
+| `app/booking/[eventId]/confirmation.tsx` | 5× `#258CF4` / `rgba(37,140,244` → `#5A7EB0` / `rgba(90,126,176` |
+| `app/booking/[eventId]/payment.tsx` | 3× `#258CF4` / `rgba(37,140,244` → correct values |
+| `app/create-event/review.tsx` | 1× `rgba(37,140,244` → `rgba(90,126,176` |
+| `app/package/[id].tsx` | 2× `rgba(37,140,244` → `rgba(90,126,176` |
+| `app/event/[id]/communication.tsx` | 14× `#4A6FA5` → `DARK_THEME.primary` |
+| `app/notifications/index.tsx` | 1× `#4A6FA5` (stylesheet) → `DARK_THEME.primary` |
+| `src/components/ui/Toggle.tsx` | outputRange second value `#4A6FA5` → `#5A7EB0` |
+| `src/components/polls/PollCard.tsx` | local `primary: '#4A6FA5'` → `'#5A7EB0'` |
+| `src/components/profile/AvatarUpload.tsx` | local `primary: '#4a6fa5'` → `'#5A7EB0'` |
+| `app/invite/[code].tsx` | Persistent login link + safe Decline navigation |
+| `app/(tabs)/_layout.tsx` | Replace `routeHasEventId` inspection with focus-effect approach |
+| `app/(tabs)/chat/index.tsx` | Add `useTabBarStore` hide/show on focus when eventId present |
+| `src/components/ui/IconCircle.tsx` | **Create** — new shared component |
+| `src/components/ui/index.ts` | Export `IconCircle` |
+| `src/constants/theme.ts` | Add `CARD_VARIANTS` documentation const |
+| `app/(tabs)/budget/index.tsx` | Auto-select last booked event, remove manual selector dialog |
+| `app/event/[id]/index.tsx` | Add `isError` + "Try Again" button |
+
+---
+
+## Task 1: Fix polls.tsx — Dark Theme Violation
+
+**This is the only genuine dark-theme-breaking visual bug in the app.** The file currently imports `colors` from `@/constants/colors` and uses `colors.light.*` values (white backgrounds, light borders) for filter chips and buttons — visually broken on the dark background.
+
+**Files:**
+- Modify: `app/event/[id]/polls.tsx`
+
+- [ ] **Step 1: Replace the import**
+
+  In `app/event/[id]/polls.tsx`, replace line 14:
+  ```typescript
+  // Remove:
+  import { colors } from '@/constants/colors';
+
+  // Add:
+  import { DARK_THEME } from '@/constants/theme';
+  ```
+
+- [ ] **Step 2: Fix RefreshControl**
+
+  Around line 182–183, replace:
+  ```typescript
+  colors={[colors.light.primary]}
+  tintColor={colors.light.primary}
+  ```
+  With:
+  ```typescript
+  colors={[DARK_THEME.primary]}
+  tintColor={DARK_THEME.primary}
+  ```
+
+- [ ] **Step 3: Fix empty-state icon circle**
+
+  Around line 192, replace:
+  ```typescript
+  backgroundColor={`${colors.light.primary}15`}
+  ```
+  With:
+  ```typescript
+  backgroundColor="rgba(90, 126, 176, 0.08)"
+  ```
+  And around line 200:
+  ```typescript
+  color={colors.light.primary}
+  ```
+  With:
+  ```typescript
+  color={DARK_THEME.primary}
+  ```
+
+- [ ] **Step 4: Fix StyleSheet values**
+
+  In the `StyleSheet.create` block (around lines 237–271), replace every `colors.light.*` reference:
+  ```typescript
+  // BEFORE (addButton):
+  backgroundColor: colors.light.primary,
+
+  // AFTER:
+  backgroundColor: DARK_THEME.primary,
+
+  // BEFORE (filterChip):
+  backgroundColor: colors.light.background,
+  borderColor: colors.light.border,
+
+  // AFTER:
+  backgroundColor: DARK_THEME.surface,
+  borderColor: DARK_THEME.glassBorder,
+
+  // BEFORE (filterChipSelected):
+  backgroundColor: colors.light.primary,
+  borderColor: colors.light.primary,
+
+  // AFTER:
+  backgroundColor: DARK_THEME.primary,
+  borderColor: DARK_THEME.primary,
+
+  // BEFORE (createButton):
+  backgroundColor: colors.light.primary,
+
+  // AFTER:
+  backgroundColor: DARK_THEME.primary,
+  ```
+
+- [ ] **Step 5: Verify no remaining `colors.light` references in polls.tsx**
+
+  ```bash
+  grep "colors\.light" app/event/\[id\]/polls.tsx
+  # Expected: no output
+  ```
+
+- [ ] **Step 6: Typecheck**
+
+  ```bash
+  cd /Users/soleilphoenix/Desktop/GameOver/game-over-app && npm run typecheck 2>&1 | grep "polls"
+  # Expected: no output
+  ```
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add app/event/\[id\]/polls.tsx
+  git commit -m "fix: replace colors.light.* with DARK_THEME in polls.tsx (dark-theme violation)"
+  ```
+
+---
+
+## Task 2: Stale Color Cleanup — `#258CF4` → `#5A7EB0`
+
+The old primary color `#258CF4` (bright blue) appears in 9 files. The canonical primary is now `#5A7EB0` (muted navy blue) from `DARK_THEME.primary`.
+
+**Files:**
+- Modify: `src/components/ui/GlassPanel.tsx`, `src/components/ui/Badge.tsx`, `src/constants/spacing.ts`, `src/hooks/usePushNotifications.ts`, `app/booking/[eventId]/confirmation.tsx`, `app/booking/[eventId]/payment.tsx`, `app/create-event/review.tsx`, `app/package/[id].tsx`
+
+- [ ] **Step 1: Fix GlassPanel icon circle background**
+
+  In `src/components/ui/GlassPanel.tsx` line 43:
+  ```typescript
+  // Before:
+  backgroundColor="rgba(37, 140, 244, 0.2)"
+
+  // After:
+  backgroundColor="rgba(90, 126, 176, 0.2)"
+  ```
+
+- [ ] **Step 2: Fix Badge primary variant background**
+
+  In `src/components/ui/Badge.tsx` line 36:
+  ```typescript
+  // Before:
+  backgroundColor: 'rgba(37, 140, 244, 0.15)',
+
+  // After:
+  backgroundColor: 'rgba(90, 126, 176, 0.15)',
+  ```
+
+- [ ] **Step 3: Fix spacing.ts shadow color**
+
+  In `src/constants/spacing.ts` line 86:
+  ```typescript
+  // Before:
+  shadowColor: '#258CF4',
+
+  // After:
+  shadowColor: '#5A7EB0',
+  ```
+
+- [ ] **Step 4: Fix usePushNotifications lightColor**
+
+  In `src/hooks/usePushNotifications.ts` around line 103:
+  ```typescript
+  // Before:
+  lightColor: '#258CF4',
+
+  // After:
+  lightColor: '#5A7EB0',
+  ```
+
+- [ ] **Step 5: Fix confirmation.tsx (5 references)**
+
+  In `app/booking/[eventId]/confirmation.tsx`, do the following replacements:
+  ```typescript
+  // All: '#258CF4' → '#5A7EB0'
+  // All: 'rgba(37, 140, 244, 0.1)' → 'rgba(90, 126, 176, 0.1)'
+  ```
+  Run verify:
+  ```bash
+  grep "258CF4\|37, 140, 244" app/booking/\[eventId\]/confirmation.tsx
+  # Expected: no output
+  ```
+
+- [ ] **Step 6: Fix payment.tsx (3 references)**
+
+  In `app/booking/[eventId]/payment.tsx`:
+  ```typescript
+  // All: '#258CF4' → '#5A7EB0'
+  // All: 'rgba(37, 140, 244, 0.1)' → 'rgba(90, 126, 176, 0.1)'
+  ```
+  Verify: `grep "258CF4\|37, 140, 244" app/booking/\[eventId\]/payment.tsx` → no output
+
+- [ ] **Step 7: Fix review.tsx and package/[id].tsx**
+
+  In `app/create-event/review.tsx`:
+  ```typescript
+  // 'rgba(37, 140, 244, 0.1)' → 'rgba(90, 126, 176, 0.1)'
+  ```
+  In `app/package/[id].tsx` (2 instances):
+  ```typescript
+  // 'rgba(37, 140, 244, 0.15)' → 'rgba(90, 126, 176, 0.15)'
+  ```
+
+- [ ] **Step 8: Verify no remaining old primary across entire codebase**
+
+  ```bash
+  grep -rn "258CF4\|37, 140, 244" \
+    app/ src/ \
+    --include="*.tsx" --include="*.ts" \
+    | grep -v node_modules
+  # Expected: no output
+  ```
+
+- [ ] **Step 9: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep -c "error"
+  # Expected: 0
+  ```
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add \
+    src/components/ui/GlassPanel.tsx \
+    src/components/ui/Badge.tsx \
+    src/constants/spacing.ts \
+    src/hooks/usePushNotifications.ts \
+    "app/booking/[eventId]/confirmation.tsx" \
+    "app/booking/[eventId]/payment.tsx" \
+    app/create-event/review.tsx \
+    "app/package/[id].tsx"
+  git commit -m "fix: replace stale #258CF4 primary color with #5A7EB0 across 8 files"
+  ```
+
+---
+
+## Task 3: Stale Color Cleanup — `#4A6FA5` → `#5A7EB0`
+
+The intermediate primary `#4A6FA5` appears in 5 files. This is a slightly darker variant that predates the unified `#5A7EB0`.
+
+**Files:**
+- Modify: `app/event/[id]/communication.tsx` (14 refs), `app/notifications/index.tsx` (1 ref), `src/components/ui/Toggle.tsx` (1 ref), `src/components/polls/PollCard.tsx` (1 ref), `src/components/profile/AvatarUpload.tsx` (1 ref)
+
+- [ ] **Step 1: Fix communication.tsx (14 references)**
+
+  In `app/event/[id]/communication.tsx`, replace all `#4A6FA5` with `#5A7EB0`:
+  ```bash
+  # Count before:
+  grep -c "4A6FA5" "app/event/[id]/communication.tsx"
+  # Expected: 14
+  ```
+  Use find-and-replace: `'#4A6FA5'` → `'#5A7EB0'` (all occurrences, case-sensitive).
+
+  ```bash
+  # Verify:
+  grep "4A6FA5\|4a6fa5" "app/event/[id]/communication.tsx"
+  # Expected: no output
+  ```
+
+- [ ] **Step 2: Fix notifications/index.tsx StyleSheet**
+
+  In `app/notifications/index.tsx`, find the StyleSheet with `backgroundColor: '#4A6FA5'` (around line 514) and replace with `backgroundColor: DARK_THEME.primary`. Note: `DARK_THEME` is already imported at the top of this file.
+
+- [ ] **Step 3: Fix Toggle.tsx animation output**
+
+  In `src/components/ui/Toggle.tsx` around line 47, the outputRange controls thumb animation:
+  ```typescript
+  // Before:
+  outputRange: ['#4B5563', '#4A6FA5'],
+
+  // After — keep OFF state gray, update ON state:
+  outputRange: ['#4B5563', '#5A7EB0'],
+  ```
+
+- [ ] **Step 4: Fix PollCard.tsx local primary**
+
+  In `src/components/polls/PollCard.tsx` around line 18:
+  ```typescript
+  // Before:
+  primary: '#4A6FA5',
+
+  // After:
+  primary: '#5A7EB0',
+  ```
+
+- [ ] **Step 5: Fix AvatarUpload.tsx local primary**
+
+  In `src/components/profile/AvatarUpload.tsx` around line 28:
+  ```typescript
+  // Before:
+  primary: '#4a6fa5',
+
+  // After:
+  primary: '#5A7EB0',
+  ```
+
+- [ ] **Step 6: Final audit — no old primaries anywhere**
+
+  ```bash
+  grep -rn "4A6FA5\|4a6fa5\|258CF4\|258cf4\|37, 140, 244" \
+    app/ src/ \
+    --include="*.tsx" --include="*.ts" \
+    | grep -v node_modules | grep -v ".test."
+  # Expected: no output
+  ```
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add \
+    "app/event/[id]/communication.tsx" \
+    app/notifications/index.tsx \
+    src/components/ui/Toggle.tsx \
+    src/components/polls/PollCard.tsx \
+    src/components/profile/AvatarUpload.tsx
+  git commit -m "fix: replace stale #4A6FA5 with unified #5A7EB0 primary across 5 files"
+  ```
+
+---
+
+## Task 4: Guest Invite — Persistent Login Link + Safe Decline
+
+**Two fixes in one file:**
+1. "Log in instead" is only shown when the email error message contains the string "Log in instead". A user who already has an account sees an error, then must notice the conditionally-rendered link. Fix: add a persistent "Already have an account? Log in →" link below the signup form, always visible.
+2. "Decline" button calls `router.back()`, which on cold-start (app opened directly from invite link) has nothing to go back to and exits the app. Fix: use `router.canGoBack()` with a fallback to `/(tabs)/events`.
+
+**Files:**
+- Modify: `app/invite/[code].tsx`
+
+- [ ] **Step 1: Add persistent login link in signup step**
+
+  In `app/invite/[code].tsx`, find the signup form's submit button (around line 495–502):
+  ```tsx
+  <Button
+    onPress={signupForm.handleSubmit(handleSignup)}
+    loading={isSubmitting}
+    testID="signup-submit-button"
+    marginTop="$2"
+  >
+    Create Account →
+  </Button>
+  ```
+  Add a persistent login link **after** that button (outside the conditional error check):
+  ```tsx
+  <Button
+    onPress={signupForm.handleSubmit(handleSignup)}
+    loading={isSubmitting}
+    testID="signup-submit-button"
+    marginTop="$2"
+  >
+    Create Account →
+  </Button>
+
+  {/* Persistent link — visible before any error occurs */}
+  <Pressable
+    onPress={handleLoginInstead}
+    style={{ alignItems: 'center', paddingVertical: 12 }}
+    testID="login-instead-link"
+  >
+    <Text fontSize={13} color={DARK_THEME.textTertiary}>
+      Already have an account?{' '}
+      <Text color={DARK_THEME.primary} textDecorationLine="underline">
+        Log in instead →
+      </Text>
+    </Text>
+  </Pressable>
+  ```
+  Keep the existing error-triggered link as-is (it gives contextual placement near the email field).
+
+- [ ] **Step 2: Fix Decline safe navigation**
+
+  Find line ~378:
+  ```tsx
+  <Pressable onPress={() => router.back()} style={{ alignItems: 'center', paddingVertical: 8 }}>
+    <Text fontSize={13} color="$textTertiary">Decline</Text>
+  </Pressable>
+  ```
+  Replace with:
+  ```tsx
+  <Pressable
+    onPress={() => {
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.replace('/(tabs)/events');
+      }
+    }}
+    style={{ alignItems: 'center', paddingVertical: 8 }}
+    testID="decline-invite-button"
+  >
+    <Text fontSize={13} color="$textTertiary">Decline</Text>
+  </Pressable>
+  ```
+
+- [ ] **Step 3: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep "invite"
+  # Expected: no output
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add "app/invite/[code].tsx"
+  git commit -m "fix: persistent login link in invite signup + safe Decline navigation on cold-start"
+  ```
+
+---
+
+## Task 5: Tab Bar Visibility — Replace Route Inspection with Focus Effects
+
+**The problem:** `app/(tabs)/_layout.tsx` currently inspects route names and params at render time to decide whether to hide the tab bar when chat/budget are opened from Event Summary. This is fragile because it relies on knowing the internal structure of nested navigators.
+
+**The fix:** The `useTabBarStore` (Zustand) is already the right approach. Budget already uses it (it calls `setTabBarHidden(true)` when `eventIdParam` is set). The problem is chat doesn't. Remove the `routeHasEventId` inspection and rely entirely on the store.
+
+**Files:**
+- Modify: `app/(tabs)/_layout.tsx`
+- Modify: `app/(tabs)/chat/index.tsx`
+
+- [ ] **Step 1: Read chat/index.tsx top section**
+
+  Read `app/(tabs)/chat/index.tsx` lines 1–80 to confirm the component structure and imports. Look for any existing `useTabBarStore` usage.
+
+- [ ] **Step 2: Add tab bar hide to chat when opened with eventId**
+
+  In `app/(tabs)/chat/index.tsx`, find where `eventId` or `eventIdParam` is derived from URL params (similar to how budget does it). Add:
+  ```typescript
+  import { useTabBarStore } from '@/stores/tabBarStore';
+
+  // Inside the component, near other hooks:
+  const { eventId: rawEventIdParam } = useLocalSearchParams<{ eventId?: string }>();
+  const setTabBarHidden = useTabBarStore((s) => s.setHidden);
+
+  // Hide tab bar when accessed from Event Summary (eventId present in URL)
+  useFocusEffect(
+    useCallback(() => {
+      if (rawEventIdParam) setTabBarHidden(true);
+      return () => setTabBarHidden(false);
+    }, [rawEventIdParam, setTabBarHidden])
+  );
+  ```
+  Import `useFocusEffect` and `useCallback` from `react` / `expo-router` as needed.
+
+- [ ] **Step 3: Simplify _layout.tsx — remove routeHasEventId**
+
+  In `app/(tabs)/_layout.tsx`, remove the `routeHasEventId` function and the two variables that use it:
+
+  ```typescript
+  // Remove these 3 blocks entirely:
+  const routeHasEventId = (route: any): boolean => {
+    if (!route) return false;
+    if ((route.params as any)?.eventId) return true;
+    if (route.state?.routes) return route.state.routes.some(routeHasEventId);
+    return false;
+  };
+  const isChatFromEventSummary = currentRoute?.name === 'chat' && routeHasEventId(currentRoute);
+  const isBudgetFromEventSummary = currentRoute?.name === 'budget' && routeHasEventId(currentRoute);
+
+  // Simplify the visibility check to:
+  if (tabBarHidden || isChannelDetailScreen) {
+    return null;
+  }
+  ```
+
+  The `tabBarHidden` store now handles both chat-from-event and budget-from-event cases.
+
+- [ ] **Step 4: Verify tab bar hide still works**
+
+  Manual test checklist (visual):
+  - Open app → tap any event → tap "Chat" tool from event summary → tab bar should be hidden
+  - Open app → tap any event → tap "Budget" tool from event summary → tab bar should be hidden
+  - Navigate back to Events tab → tab bar should be visible again
+
+- [ ] **Step 5: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep -E "layout|chat" | grep error
+  # Expected: no output
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add "app/(tabs)/_layout.tsx" "app/(tabs)/chat/index.tsx"
+  git commit -m "fix: replace fragile route-inspection for tab bar with store-based focus effects"
+  ```
+
+---
+
+## Task 6: Event Detail — Network Error State
+
+**The Events list screen already has a "Tap to retry" error banner. Event Detail (`app/event/[id]/index.tsx`) currently has no error handling for failed data loads — the screen just shows empty/loading state indefinitely.**
+
+**Files:**
+- Modify: `app/event/[id]/index.tsx`
+
+- [ ] **Step 1: Read the useEvent hook call in index.tsx**
+
+  ```bash
+  grep -n "useEvent\|isError\|isLoading\|error" app/event/\[id\]/index.tsx | head -20
+  ```
+  Note the variable names for `error` and `isLoading` from the hook.
+
+- [ ] **Step 2: Add error state rendering**
+
+  After the existing loading state check, add an error state. Find the section near the top of the return statement where loading is handled. Add:
+  ```tsx
+  // After the loading guard (isLoading && !event check), add:
+  if (eventError && !event) {
+    return (
+      <View style={{ flex: 1, backgroundColor: DARK_THEME.background, justifyContent: 'center', alignItems: 'center', padding: 24 }}>
+        <Ionicons name="cloud-offline-outline" size={48} color={DARK_THEME.textTertiary} />
+        <Text style={{ color: DARK_THEME.textPrimary, fontSize: 16, fontWeight: '600', marginTop: 16, marginBottom: 8 }}>
+          {t.common.error}
+        </Text>
+        <Text style={{ color: DARK_THEME.textSecondary, fontSize: 14, textAlign: 'center', marginBottom: 24 }}>
+          {t.events.loadError}
+        </Text>
+        <Pressable
+          onPress={() => refetch()}
+          style={{ backgroundColor: DARK_THEME.primary, paddingHorizontal: 24, paddingVertical: 12, borderRadius: 12 }}
+        >
+          <Text style={{ color: '#FFFFFF', fontWeight: '600' }}>{t.common.retry}</Text>
+        </Pressable>
+      </View>
+    );
+  }
+  ```
+  Make sure `eventError` and `refetch` are destructured from the data hook, and `Pressable` and `Ionicons` are imported.
+
+- [ ] **Step 3: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep "event.*index"
+  # Expected: no output
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add "app/event/[id]/index.tsx"
+  git commit -m "fix: add network error state with retry button to Event Detail screen"
+  ```
+
+---
+
+## Task 7: Extract IconCircle Shared Component
+
+**30+ instances of the same pattern (32px circle, translucent colored background, Ionicon inside) are spread across Profile, Event Detail, Budget, Notifications, GlassPanel, ShareEventBanner.** Extracting this eliminates maintenance drift and ensures consistent sizing.
+
+**Files:**
+- Create: `src/components/ui/IconCircle.tsx`
+- Modify: `src/components/ui/index.ts` (add export)
+- Migrate 3–5 key screens as proof-of-concept (not required to migrate every instance)
+
+- [ ] **Step 1: Create the component**
+
+  Create `src/components/ui/IconCircle.tsx`:
+  ```tsx
+  /**
+   * IconCircle — shared 32px icon-in-circle component.
+   * Used in Profile, Event Detail, Budget, Notifications, GlassPanel, etc.
+   */
+  import React from 'react';
+  import { View, ViewStyle } from 'react-native';
+  import { Ionicons } from '@expo/vector-icons';
+
+  interface IconCircleProps {
+    /** Ionicons icon name */
+    name: string;
+    /** Icon size — defaults to 18 */
+    iconSize?: number;
+    /** Icon color */
+    color: string;
+    /** Circle background color (e.g. 'rgba(90,126,176,0.2)') */
+    backgroundColor: string;
+    /** Circle diameter — defaults to 32 */
+    size?: number;
+    style?: ViewStyle;
+  }
+
+  export function IconCircle({
+    name,
+    iconSize = 18,
+    color,
+    backgroundColor,
+    size = 32,
+    style,
+  }: IconCircleProps) {
+    return (
+      <View
+        style={[
+          {
+            width: size,
+            height: size,
+            borderRadius: size / 2,
+            backgroundColor,
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
+          style,
+        ]}
+      >
+        <Ionicons name={name as any} size={iconSize} color={color} />
+      </View>
+    );
+  }
+
+  export default IconCircle;
+  ```
+
+- [ ] **Step 2: Export from ui/index.ts**
+
+  Check if `src/components/ui/index.ts` exists:
+  ```bash
+  ls src/components/ui/index.ts 2>/dev/null && echo "exists" || echo "missing"
+  ```
+  If it exists, add: `export { IconCircle } from './IconCircle';`
+  If it doesn't exist (or doesn't export), add the export to whichever barrel file the other ui components use (check how `GlassPanel` is imported in other files to find the barrel).
+
+- [ ] **Step 3: Migrate GlassPanel to use IconCircle**
+
+  In `src/components/ui/GlassPanel.tsx`, replace the inline icon circle (lines ~39–48) with:
+  ```tsx
+  import { IconCircle } from './IconCircle';
+
+  // Replace the inline YStack + Ionicons with:
+  <IconCircle
+    name={icon}
+    color={DARK_THEME.primary}
+    backgroundColor="rgba(90, 126, 176, 0.2)"
+  />
+  ```
+
+- [ ] **Step 4: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep "IconCircle\|GlassPanel"
+  # Expected: no output
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/components/ui/IconCircle.tsx src/components/ui/GlassPanel.tsx
+  # Add index.ts if changed:
+  git add src/components/ui/index.ts 2>/dev/null
+  git commit -m "feat: extract IconCircle shared component, migrate GlassPanel"
+  ```
+
+---
+
+## Task 8: Document Card Variants in theme.ts
+
+**3 divergent card styles are used without documentation, so developers choose arbitrarily. This task adds a `CARD_VARIANTS` const to `theme.ts` that names the three styles and documents when to use each.**
+
+**Files:**
+- Modify: `src/constants/theme.ts`
+
+- [ ] **Step 1: Add CARD_VARIANTS to theme.ts**
+
+  At the end of `src/constants/theme.ts`, after the `DARK_THEME` export, add:
+  ```typescript
+  /**
+   * Named card style variants — use these instead of choosing background colors ad-hoc.
+   *
+   * card      — primary surface, used for main content cards (events, packages, profile sections)
+   * glassCard — translucent glass effect, used for overlays and contextual cards
+   * deepCard  — deeper background, used for nested content within a card (sub-sections)
+   */
+  export const CARD_VARIANTS = {
+    /** Opaque surface — main content cards */
+    card:      { backgroundColor: DARK_THEME.surface },          // '#1E2329'
+    /** Translucent glass — overlays, contextual cards */
+    glassCard: { backgroundColor: 'rgba(45, 55, 72, 0.4)' },
+    /** Deep surface — nested content within cards */
+    deepCard:  { backgroundColor: DARK_THEME.surfaceCard },      // '#23272F'
+  } as const;
+  ```
+
+- [ ] **Step 2: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep "theme"
+  # Expected: no output
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/constants/theme.ts
+  git commit -m "docs: add CARD_VARIANTS to theme.ts to formalize the three card style patterns"
+  ```
+
+---
+
+## Task 9: Budget — Auto-Select Last Booked Event
+
+**The Budget tab in standalone mode (not opened from Event Summary) shows a manual event-selector dialog. Users with only one event shouldn't need to tap to select it. Fix: auto-select the most recently created booked event if only one booked event exists.**
+
+**Files:**
+- Modify: `app/(tabs)/budget/index.tsx`
+
+- [ ] **Step 1: Read the current auto-selection logic**
+
+  ```bash
+  grep -n "setSelectedEventId\|selectedEventId\|bookedEvents\|hasBookedEvents" \
+    "app/(tabs)/budget/index.tsx" | head -20
+  ```
+  Understand where `selectedEventId` is set and how `bookedEvents` is derived.
+
+- [ ] **Step 2: Add auto-selection useEffect**
+
+  Find the `useEffect` block that loads cached data or the block where `selectedEventId` is initialized. Add an effect that auto-selects when there is exactly one booked event and no eventId was passed via URL:
+  ```typescript
+  // After: const [selectedEventId, setSelectedEventId] = useState<string | null>(eventIdParam || null);
+
+  // Auto-select the single booked event to skip the manual selector dialog
+  useEffect(() => {
+    if (selectedEventId) return; // Already selected (URL param or user choice)
+    if (!bookedEvents || bookedEvents.length === 0) return;
+    if (bookedEvents.length === 1) {
+      setSelectedEventId(bookedEvents[0].id);
+    }
+    // Multiple events: leave selectedEventId null so the user can choose
+  }, [bookedEvents, selectedEventId]);
+  ```
+  Where `bookedEvents` is the filtered list of events with status `'booked'`. Confirm the variable name by reading the file first (Step 1).
+
+- [ ] **Step 3: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep "budget"
+  # Expected: no output
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add "app/(tabs)/budget/index.tsx"
+  git commit -m "ux: auto-select single booked event in Budget tab (skip manual selector)"
+  ```
+
+---
+
+## Task 10: Button Component in Main Tab Screens
+
+**The `Button` component (with press animation, loading state, `pressStyle` scale) is used in Wizard/Auth/Booking but not in main tabs. Budget, Event, and Profile use raw `Pressable` for primary actions. This creates two visual "classes" of buttons.**
+
+**Scope:** Only address the 3 highest-impact buttons: Budget "Pay Remaining Balance", Event "Book Package" (packages CTA), Profile "Log Out". Do NOT refactor all Pressables — only primary CTA buttons.
+
+**Files:**
+- Modify: `app/(tabs)/budget/index.tsx`
+- Modify: `app/(tabs)/profile/index.tsx`
+
+- [ ] **Step 1: Read how "Pay Remaining Balance" button is implemented**
+
+  ```bash
+  grep -n "payRemainingBtn\|Pay Remaining\|handlePayRemaining" \
+    "app/(tabs)/budget/index.tsx" | head -10
+  ```
+
+- [ ] **Step 2: Replace "Pay Remaining Balance" button in Budget**
+
+  Find the raw `Pressable` that triggers the remaining-balance payment. Replace with the `Button` component:
+  ```tsx
+  // Before (raw Pressable pattern):
+  <Pressable onPress={handlePayRemaining} style={styles.payRemainingButton}>
+    <Text style={styles.payRemainingText}>{t.budget.payRemainingBtn}</Text>
+  </Pressable>
+
+  // After (using shared Button):
+  import { Button } from '@/components/ui/Button';
+
+  <Button
+    onPress={handlePayRemaining}
+    variant="primary"
+    testID="pay-remaining-button"
+    size="$5"
+  >
+    {t.budget.payRemainingBtn}
+  </Button>
+  ```
+  Confirm `Button` is not already imported in this file first. If the existing button has specific style overrides (e.g. fills the card width), keep them via a wrapping `View` or the `style` prop.
+
+- [ ] **Step 3: Replace "Log Out" button in Profile**
+
+  In `app/(tabs)/profile/index.tsx`, find the Log Out button. Replace the raw `Pressable` with:
+  ```tsx
+  <Button
+    variant="outline"
+    onPress={handleLogout}
+    testID="logout-button"
+  >
+    {t.profile.logOut}
+  </Button>
+  ```
+
+- [ ] **Step 4: Typecheck**
+
+  ```bash
+  npm run typecheck 2>&1 | grep -E "budget|profile" | grep error
+  # Expected: no output
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add "app/(tabs)/budget/index.tsx" "app/(tabs)/profile/index.tsx"
+  git commit -m "ux: replace raw Pressable with Button component for Pay Remaining + Log Out CTAs"
+  ```
+
+---
+
+## Final Verification
+
+- [ ] **Run full typecheck — 0 errors**
+
+  ```bash
+  cd /Users/soleilphoenix/Desktop/GameOver/game-over-app
+  npm run typecheck 2>&1 | grep -c "error TS"
+  # Expected: 0
+  ```
+
+- [ ] **Run linter**
+
+  ```bash
+  npm run lint 2>&1 | grep -c "error"
+  # Expected: 0
+  ```
+
+- [ ] **Color audit — no old primaries**
+
+  ```bash
+  grep -rn "258CF4\|4A6FA5\|4a6fa5\|37, 140, 244\|colors\.light\." \
+    app/ src/ \
+    --include="*.tsx" --include="*.ts" \
+    | grep -v node_modules | grep -v ".test."
+  # Expected: no output
+  ```
+
+- [ ] **Final commit summary**
+
+  ```bash
+  git log --oneline -10
+  ```
+
+---
+
+## Findings Addressed
+
+| # | Finding | Agent | Task | Status |
+|---|---------|-------|------|--------|
+| 1 | Wizard step indicator missing | UX Architect | — | **Already implemented** in `create-event/_layout.tsx` |
+| 2 | Guest "already have account" dead-end | UX Architect | Task 4 | ✅ |
+| 3 | Tab bar visibility fragile (route inspection) | UX Architect | Task 5 | ✅ |
+| 4 | Budget 2 modes (selector dialog) | UX Architect | Task 9 | ✅ |
+| 5 | DARK_THEME local drift (#4A6FA5) | UX Architect | Task 3 | ✅ |
+| 6 | "Decline" invite cold-start crash | UX Architect | Task 4 | ✅ |
+| 7 | Network error states (Event Detail) | UX Architect | Task 6 | ✅ |
+| 8 | Events screen error state | UX Architect | — | **Already implemented** (error banner exists) |
+| 9 | Budget auto-select | UX Architect | Task 9 | ✅ |
+| 10 | Persistent login link | UX Architect | Task 4 | ✅ |
+| 11 | polls.tsx dark theme violation | UI Designer | Task 1 | ✅ |
+| 12 | Stale #258CF4 in GlassPanel, Badge, spacing.ts + 5 app files | UI Designer | Task 2 | ✅ |
+| 13 | Stale #4A6FA5 in communication.tsx + 4 more | UI Designer | Task 3 | ✅ |
+| 14 | Button fragmentation in main tabs | UI Designer | Task 10 | ✅ |
+| 15 | 3 divergent card styles undocumented | UI Designer | Task 8 | ✅ |
+| 16 | Typography system unused | UI Designer | — | **Out of scope** — full typography migration is a major refactor; inline font sizes work correctly |
+| 17 | 30+ IconCircle inline | UI Designer | Task 7 | ✅ (component created + GlassPanel migrated) |
+| 18 | GlassPanel icon color (#258CF4) | UI Designer | Task 2 | ✅ |
+| 19 | Badge primary color (#258CF4) | UI Designer | Task 2 | ✅ |
+| 20 | usePushNotifications lightColor | UI Designer | Task 2 | ✅ |
+| 21 | spacing.ts shadowColor | UI Designer | Task 2 | ✅ |
+| 22 | Login redirect after invite | UX Architect | Task 4 | ✅ |

--- a/game-over-app/src/components/chat/ChannelListItem.tsx
+++ b/game-over-app/src/components/chat/ChannelListItem.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { XStack, YStack, Text } from 'tamagui';
 import { Ionicons } from '@expo/vector-icons';
-import { colors } from '@/constants/colors';
+import { DARK_THEME } from '@/constants/theme';
 import type { Database } from '@/lib/supabase/types';
 
 type ChatChannel = Database['public']['Tables']['chat_channels']['Row'];
@@ -36,7 +36,7 @@ const getCategoryIcon = (category: ChatChannel['category']): keyof typeof Ionico
 const getCategoryColor = (category: ChatChannel['category']): string => {
   switch (category) {
     case 'general':
-      return colors.light.primary;
+      return DARK_THEME.primary;
     case 'activities':
       return '#47B881';
     case 'accommodation':
@@ -44,7 +44,7 @@ const getCategoryColor = (category: ChatChannel['category']): string => {
     case 'budget':
       return '#FF8551';
     default:
-      return colors.light.primary;
+      return DARK_THEME.primary;
   }
 };
 
@@ -137,7 +137,7 @@ export function ChannelListItem({ channel, onPress, testID }: ChannelListItemPro
         </YStack>
 
         {/* Chevron */}
-        <Ionicons name="chevron-forward" size={18} color={colors.light.textTertiary} />
+        <Ionicons name="chevron-forward" size={18} color={DARK_THEME.textTertiary} />
       </XStack>
     </Pressable>
   );
@@ -145,13 +145,13 @@ export function ChannelListItem({ channel, onPress, testID }: ChannelListItemPro
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.light.surface,
+    backgroundColor: DARK_THEME.surface,
     paddingHorizontal: 16,
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: colors.light.border,
+    borderBottomColor: DARK_THEME.glassBorder,
   },
   pressed: {
-    backgroundColor: colors.light.background,
+    backgroundColor: DARK_THEME.background,
   },
 });

--- a/game-over-app/src/components/polls/CreatePollModal.tsx
+++ b/game-over-app/src/components/polls/CreatePollModal.tsx
@@ -8,7 +8,7 @@ import { Modal, Pressable, ScrollView, StyleSheet, TextInput, Alert } from 'reac
 import { YStack, XStack, Text, Spinner } from 'tamagui';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { colors } from '@/constants/colors';
+import { DARK_THEME } from '@/constants/theme';
 import { Button } from '@/components/ui/Button';
 import type { Database } from '@/lib/supabase/types';
 
@@ -158,7 +158,7 @@ export function CreatePollModal({
               value={question}
               onChangeText={setQuestion}
               placeholder="What would you like to ask?"
-              placeholderTextColor={colors.light.textTertiary}
+              placeholderTextColor={DARK_THEME.textTertiary}
               multiline
               maxLength={200}
               testID="poll-question-input"
@@ -187,7 +187,7 @@ export function CreatePollModal({
                   <Ionicons
                     name={cat.icon}
                     size={16}
-                    color={category === cat.value ? 'white' : colors.light.textSecondary}
+                    color={category === cat.value ? 'white' : DARK_THEME.textSecondary}
                   />
                   <Text
                     fontSize="$2"
@@ -231,7 +231,7 @@ export function CreatePollModal({
                   value={option}
                   onChangeText={(value) => handleOptionChange(index, value)}
                   placeholder={`Option ${index + 1}`}
-                  placeholderTextColor={colors.light.textTertiary}
+                  placeholderTextColor={DARK_THEME.textTertiary}
                   maxLength={100}
                   testID={`poll-option-${index}`}
                 />
@@ -241,7 +241,7 @@ export function CreatePollModal({
                     style={styles.removeButton}
                     testID={`remove-option-${index}`}
                   >
-                    <Ionicons name="close-circle" size={24} color={colors.light.error} />
+                    <Ionicons name="close-circle" size={24} color={DARK_THEME.error} />
                   </Pressable>
                 )}
               </XStack>
@@ -249,7 +249,7 @@ export function CreatePollModal({
 
             {options.length < 6 && (
               <Pressable style={styles.addOptionButton} onPress={handleAddOption} testID="add-option-button">
-                <Ionicons name="add" size={20} color={colors.light.primary} />
+                <Ionicons name="add" size={20} color={DARK_THEME.primary} />
                 <Text color="$primary" fontWeight="500">
                   Add Option
                 </Text>
@@ -299,13 +299,13 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   questionInput: {
-    backgroundColor: colors.light.surface,
+    backgroundColor: DARK_THEME.surface,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: colors.light.border,
+    borderColor: DARK_THEME.glassBorder,
     padding: 16,
     fontSize: 16,
-    color: colors.light.textPrimary,
+    color: DARK_THEME.textPrimary,
     minHeight: 80,
     textAlignVertical: 'top',
   },
@@ -316,23 +316,23 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 10,
     borderRadius: 20,
-    backgroundColor: colors.light.surface,
+    backgroundColor: DARK_THEME.surface,
     borderWidth: 1,
-    borderColor: colors.light.border,
+    borderColor: DARK_THEME.glassBorder,
   },
   categoryChipSelected: {
-    backgroundColor: colors.light.primary,
-    borderColor: colors.light.primary,
+    backgroundColor: DARK_THEME.primary,
+    borderColor: DARK_THEME.primary,
   },
   optionInput: {
     flex: 1,
-    backgroundColor: colors.light.surface,
+    backgroundColor: DARK_THEME.surface,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: colors.light.border,
+    borderColor: DARK_THEME.glassBorder,
     padding: 12,
     fontSize: 15,
-    color: colors.light.textPrimary,
+    color: DARK_THEME.textPrimary,
   },
   removeButton: {
     padding: 4,
@@ -346,7 +346,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     borderWidth: 1,
     borderStyle: 'dashed',
-    borderColor: colors.light.primary,
-    backgroundColor: `${colors.light.primary}08`,
+    borderColor: DARK_THEME.primary,
+    backgroundColor: 'rgba(90, 126, 176, 0.08)',
   },
 });

--- a/game-over-app/src/components/polls/PollCard.tsx
+++ b/game-over-app/src/components/polls/PollCard.tsx
@@ -15,7 +15,7 @@ const DARK_THEME = {
   backgroundDark: '#15181D',
   surfaceDark: '#1E2329',
   surfaceCard: '#23272F',
-  primary: '#4A6FA5',
+  primary: '#5A7EB0',
   border: 'rgba(255, 255, 255, 0.05)',
   textPrimary: '#FFFFFF',
   textSecondary: '#9CA3AF',

--- a/game-over-app/src/components/profile/AvatarUpload.tsx
+++ b/game-over-app/src/components/profile/AvatarUpload.tsx
@@ -25,7 +25,7 @@ interface AvatarUploadProps {
 
 const THEME = {
   background: '#2D3748',
-  primary: '#4a6fa5',
+  primary: '#5A7EB0',
   textPrimary: '#FFFFFF',
   border: 'rgba(255, 255, 255, 0.08)',
 };

--- a/game-over-app/src/components/ui/Badge.tsx
+++ b/game-over-app/src/components/ui/Badge.tsx
@@ -33,7 +33,7 @@ const StyledBadge = styled(XStack, {
         backgroundColor: '$backgroundHover',
       },
       primary: {
-        backgroundColor: 'rgba(37, 140, 244, 0.15)',
+        backgroundColor: 'rgba(90, 126, 176, 0.15)',
       },
       bestMatch: {
         backgroundColor: 'rgba(255, 215, 0, 0.2)',

--- a/game-over-app/src/components/ui/GlassPanel.tsx
+++ b/game-over-app/src/components/ui/GlassPanel.tsx
@@ -40,7 +40,7 @@ export function GlassPanel({
           width={32}
           height={32}
           borderRadius="$full"
-          backgroundColor="rgba(37, 140, 244, 0.2)"
+          backgroundColor="rgba(90, 126, 176, 0.2)"
           alignItems="center"
           justifyContent="center"
         >

--- a/game-over-app/src/components/ui/GlassPanel.tsx
+++ b/game-over-app/src/components/ui/GlassPanel.tsx
@@ -6,8 +6,8 @@
 
 import React from 'react';
 import { YStack, XStack, Text } from 'tamagui';
-import { Ionicons } from '@expo/vector-icons';
 import { DARK_THEME } from '@/constants/theme';
+import { IconCircle } from './IconCircle';
 
 export interface GlassPanelProps {
   icon: string;
@@ -36,16 +36,11 @@ export function GlassPanel({
     >
       {/* Header with Icon */}
       <XStack alignItems="center" gap="$3" marginBottom="$5">
-        <YStack
-          width={32}
-          height={32}
-          borderRadius="$full"
+        <IconCircle
+          name={icon}
+          color={DARK_THEME.primary}
           backgroundColor="rgba(90, 126, 176, 0.2)"
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Ionicons name={icon as any} size={18} color={DARK_THEME.primary} />
-        </YStack>
+        />
         <Text fontSize="$4" fontWeight="600" color="$textPrimary" flex={1}>
           {title}
         </Text>

--- a/game-over-app/src/components/ui/IconCircle.tsx
+++ b/game-over-app/src/components/ui/IconCircle.tsx
@@ -1,0 +1,50 @@
+/**
+ * IconCircle — shared 32px icon-in-circle component.
+ * Used in Profile, Event Detail, Budget, Notifications, GlassPanel, etc.
+ */
+import React from 'react';
+import { View, ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface IconCircleProps {
+  /** Ionicons icon name */
+  name: string;
+  /** Icon size — defaults to 18 */
+  iconSize?: number;
+  /** Icon color */
+  color: string;
+  /** Circle background color (e.g. 'rgba(90,126,176,0.2)') */
+  backgroundColor: string;
+  /** Circle diameter — defaults to 32 */
+  size?: number;
+  style?: ViewStyle;
+}
+
+export function IconCircle({
+  name,
+  iconSize = 18,
+  color,
+  backgroundColor,
+  size = 32,
+  style,
+}: IconCircleProps) {
+  return (
+    <View
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        style,
+      ]}
+    >
+      <Ionicons name={name as any} size={iconSize} color={color} />
+    </View>
+  );
+}
+
+export default IconCircle;

--- a/game-over-app/src/components/ui/SocialButton.tsx
+++ b/game-over-app/src/components/ui/SocialButton.tsx
@@ -13,6 +13,7 @@ import {
   PressableProps,
 } from 'react-native';
 import { colors } from '@/constants/colors';
+import { DARK_THEME } from '@/constants/theme';
 import { spacing, borderRadius, layout } from '@/constants/spacing';
 
 type SocialProvider = 'apple' | 'google' | 'facebook';
@@ -61,7 +62,7 @@ export function SocialButton({
         styles.button,
         {
           backgroundColor: config.backgroundColor,
-          borderColor: provider === 'google' ? colors.light.border : config.backgroundColor,
+          borderColor: provider === 'google' ? DARK_THEME.glassBorder : config.backgroundColor,
         },
         pressed && !isDisabled && styles.pressed,
         isDisabled && styles.disabled,

--- a/game-over-app/src/components/ui/Toggle.tsx
+++ b/game-over-app/src/components/ui/Toggle.tsx
@@ -44,7 +44,7 @@ export function Toggle({ value, onValueChange, disabled = false, testID }: Toggl
 
   const backgroundColor = animatedValue.interpolate({
     inputRange: [0, 1],
-    outputRange: ['#4B5563', '#4A6FA5'],
+    outputRange: ['#4B5563', '#5A7EB0'],
   });
 
   return (

--- a/game-over-app/src/components/ui/index.ts
+++ b/game-over-app/src/components/ui/index.ts
@@ -38,3 +38,6 @@ export type { SkeletonProps } from './Skeleton';
 
 // Re-export SocialButton if it exists
 export { SocialButton } from './SocialButton';
+
+// IconCircle
+export { IconCircle } from './IconCircle';

--- a/game-over-app/src/constants/spacing.ts
+++ b/game-over-app/src/constants/spacing.ts
@@ -83,7 +83,7 @@ export const shadows = {
     elevation: 12,
   },
   primary: {
-    shadowColor: '#258CF4',
+    shadowColor: '#5A7EB0',
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 12,

--- a/game-over-app/src/constants/theme.ts
+++ b/game-over-app/src/constants/theme.ts
@@ -44,3 +44,19 @@ export const DARK_THEME = {
 } as const;
 
 export type DarkTheme = typeof DARK_THEME;
+
+/**
+ * Named card style variants — use these instead of choosing background colors ad-hoc.
+ *
+ * card      — primary surface, used for main content cards (events, packages, profile sections)
+ * glassCard — translucent glass effect, used for overlays and contextual cards
+ * deepCard  — deeper background, used for nested content within a card (sub-sections)
+ */
+export const CARD_VARIANTS = {
+  /** Opaque surface — main content cards */
+  card:      { backgroundColor: DARK_THEME.surface },          // '#1E2329'
+  /** Translucent glass — overlays, contextual cards */
+  glassCard: { backgroundColor: 'rgba(45, 55, 72, 0.4)' },
+  /** Deep surface — nested content within cards */
+  deepCard:  { backgroundColor: DARK_THEME.surfaceCard },      // '#23272F'
+} as const;

--- a/game-over-app/src/hooks/usePushNotifications.ts
+++ b/game-over-app/src/hooks/usePushNotifications.ts
@@ -100,7 +100,7 @@ export function usePushNotifications() {
           name: 'Default',
           importance: Notifications.AndroidImportance.MAX,
           vibrationPattern: [0, 250, 250, 250],
-          lightColor: '#258CF4',
+          lightColor: '#5A7EB0',
         });
       }
 

--- a/game-over-app/src/i18n/de.ts
+++ b/game-over-app/src/i18n/de.ts
@@ -493,6 +493,18 @@ const de: TranslationKeys = {
     payRemainingSubtitle: '75% Restbetrag vor dem Event fällig',
     notif14DayTitle: 'Restzahlung bald fällig',
     notif14DayBody: '{{eventName}} ist in {{count}} Tagen. Bezahle jetzt deinen Restbetrag von {{amount}}.',
+    // Alert strings
+    noEventSelected: 'Kein Event ausgewählt',
+    noEventSelectedMsg: 'Wähle zuerst ein Event aus, um Einladungen zu senden.',
+    sendFailed: 'Senden fehlgeschlagen',
+    errorSendingReminders: 'Erinnerungen konnten nicht gesendet werden. Versuche es erneut.',
+    confirmPayment: 'Zahlung bestätigen',
+    confirmPaymentMsg: 'Hast du deinen Anteil an den Organisator überwiesen?',
+    notYet: 'Noch nicht',
+    yesPaid: 'Ja, ich habe bezahlt',
+    thankYou: 'Danke!',
+    paymentConfirmedMsg: 'Deine Zahlung wurde bestätigt. Der Organisator wird benachrichtigt.',
+    errorUpdatingStatus: 'Status konnte nicht aktualisiert werden. Bitte versuche es erneut.',
   },
 
   // ─── Chat Screen ─────────────────────────────
@@ -547,6 +559,12 @@ const de: TranslationKeys = {
     earlier: 'Früher',
     allCaughtUp: 'Alles erledigt!',
     noNewNotifications: 'Du hast keine neuen Benachrichtigungen',
+    // Guest payment confirmation alert
+    confirmPayment: 'Zahlung bestätigen',
+    confirmPaymentMsg: 'Hast du deinen Anteil an {{name}} überwiesen?',
+    notYet: 'Noch nicht',
+    yesPaid: 'Ja, ich habe bezahlt',
+    errorConfirmPayment: 'Zahlung konnte nicht bestätigt werden. Bitte versuche es erneut.',
   },
 
   // ─── Event Detail ─────────────────────────────
@@ -593,6 +611,9 @@ const de: TranslationKeys = {
     viewTips: 'Lokale Tipps & Empfehlungen ansehen',
     inviteYourGroup: 'Gruppe einladen',
     shareSubtext: 'Einladungslink teilen, um loszulegen',
+    // Alert strings
+    organizerOnly: 'Nur für Organisatoren',
+    organizerOnlyMsg: 'Nur der Event-Organisator kann Planungsschritte verwalten.',
   },
 
   // ─── Common ────────────────────────────────────

--- a/game-over-app/src/i18n/en.ts
+++ b/game-over-app/src/i18n/en.ts
@@ -501,6 +501,18 @@ const en = {
     payRemainingSubtitle: '75% balance due before event',
     notif14DayTitle: 'Final Payment Due Soon',
     notif14DayBody: '{{eventName}} is in {{count}} days. Pay your remaining balance of {{amount}} to secure your booking.',
+    // Alert strings
+    noEventSelected: 'No Event Selected',
+    noEventSelectedMsg: 'Select an event first to send invitations.',
+    sendFailed: 'Send Failed',
+    errorSendingReminders: 'Could not send reminders. Try again.',
+    confirmPayment: 'Confirm Payment',
+    confirmPaymentMsg: 'Have you transferred your share to the organizer?',
+    notYet: 'Not yet',
+    yesPaid: "Yes, I've Paid",
+    thankYou: 'Thank you!',
+    paymentConfirmedMsg: 'Your payment has been confirmed. The organizer will be notified.',
+    errorUpdatingStatus: 'Could not update status. Please try again.',
   },
 
   // ─── Chat Screen ─────────────────────────────
@@ -555,6 +567,12 @@ const en = {
     earlier: 'Earlier',
     allCaughtUp: 'All Caught Up!',
     noNewNotifications: 'You have no new notifications',
+    // Guest payment confirmation alert
+    confirmPayment: 'Confirm Payment',
+    confirmPaymentMsg: 'Have you transferred your share to {{name}}?',
+    notYet: 'Not yet',
+    yesPaid: "Yes, I've Paid",
+    errorConfirmPayment: 'Could not confirm payment. Please try again.',
   },
 
   // ─── Event Detail ─────────────────────────────
@@ -609,6 +627,9 @@ const en = {
     // Invite group
     inviteYourGroup: 'Invite Your Group',
     shareSubtext: 'Share invite link to get started',
+    // Alert strings
+    organizerOnly: 'Organizer Only',
+    organizerOnlyMsg: 'Only the event organizer can manage planning steps.',
   },
 
   // ─── Common ────────────────────────────────────

--- a/game-over-app/src/lib/storage.ts
+++ b/game-over-app/src/lib/storage.ts
@@ -15,6 +15,23 @@ import Constants, { ExecutionEnvironment } from 'expo-constants';
 // Detect if we're running in Expo Go (StoreClient = Expo Go app)
 const isExpoGo = Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
 
+// Load MMKV once at module level so the bundler can statically analyse the import.
+// Wrapped in try-catch: the native module throws when running in Expo Go or when
+// the binary hasn't been built yet (e.g. first `expo prebuild`).
+let MMKVClass: (new (options: { id: string }) => {
+  getString: (key: string) => string | undefined;
+  set: (key: string, value: string) => void;
+  delete: (key: string) => void;
+}) | null = null;
+
+if (!isExpoGo) {
+  try {
+    MMKVClass = require('react-native-mmkv').MMKV;
+  } catch {
+    console.warn('[Storage] react-native-mmkv native module not available — will fall back to AsyncStorage');
+  }
+}
+
 // Storage interface that matches what Supabase and Zustand expect
 export interface StorageAdapter {
   getItem: (key: string) => string | null | Promise<string | null>;
@@ -65,8 +82,8 @@ export function createStorage(namespace: string): AsyncStorageAdapter {
   // Wrap initialization in try-catch: MMKV can fail to write manifest in Expo Go sandbox
   let storage: any;
   try {
-    const { MMKV } = require('react-native-mmkv');
-    storage = new MMKV({ id: namespace });
+    if (!MMKVClass) throw new Error('MMKV not available');
+    storage = new MMKVClass({ id: namespace });
     // Verify it works with a probe read — throws if manifest write failed
     storage.getString('__probe__');
   } catch {
@@ -129,8 +146,8 @@ export function createSyncStorage(namespace: string) {
   // Use MMKV for development/production builds
   let storage: any;
   try {
-    const { MMKV } = require('react-native-mmkv');
-    storage = new MMKV({ id: namespace });
+    if (!MMKVClass) throw new Error('MMKV not available');
+    storage = new MMKVClass({ id: namespace });
     storage.getString('__probe__');
   } catch {
     console.warn(`[Storage] MMKV init failed for "${namespace}", falling back to AsyncStorage`);
@@ -171,12 +188,15 @@ export function createSyncStorage(namespace: string) {
  * Direct delete for a namespace (used by wizardStore.clearDraft)
  */
 export function deleteFromStorage(namespace: string, key: string): void {
-  if (isExpoGo) {
+  if (isExpoGo || !MMKVClass) {
     AsyncStorage.removeItem(`${namespace}:${key}`);
   } else {
-    const { MMKV } = require('react-native-mmkv');
-    const storage = new MMKV({ id: namespace });
-    storage.delete(key);
+    try {
+      const storage = new MMKVClass({ id: namespace });
+      storage.delete(key);
+    } catch {
+      AsyncStorage.removeItem(`${namespace}:${key}`);
+    }
   }
 }
 

--- a/game-over-app/src/stores/wizardStore.ts
+++ b/game-over-app/src/stores/wizardStore.ts
@@ -38,6 +38,7 @@ export interface DraftSnapshot {
   id: string;
   createdAt: string;
   updatedAt: string;
+  createdBy: string | null;
   partyType: PartyType | null;
   honoreeName: string;
   honoreeLastName: string;
@@ -102,6 +103,7 @@ interface WizardState {
   currentStep: number;
   lastSavedAt: string | null;
   isDirty: boolean;
+  activeDraftOwner: string | null;
 
   // Multi-draft
   activeDraftId: string | null;
@@ -155,7 +157,7 @@ interface WizardActions {
   getTimeSinceLastSave: () => number | null;
 
   // Multi-draft actions
-  startNewDraft: () => void;
+  startNewDraft: (userId?: string) => void;
   loadDraft: (id: string) => void;
   deleteDraft: (id: string) => void;
   getAllDrafts: () => DraftSnapshot[];
@@ -216,6 +218,7 @@ const initialState: WizardState = {
   ...initialWizardFields,
   lastSavedAt: null,
   isDirty: false,
+  activeDraftOwner: null,
   activeDraftId: null,
   savedDrafts: {},
 };
@@ -229,6 +232,7 @@ function snapshotFromState(state: WizardState, id: string, now: string): DraftSn
     id,
     createdAt: now,
     updatedAt: now,
+    createdBy: state.activeDraftOwner,
     partyType: state.partyType,
     honoreeName: state.honoreeName,
     honoreeLastName: state.honoreeLastName,
@@ -394,7 +398,7 @@ export const useWizardStore = create<WizardState & WizardActions>()(
         if (state.activeDraftId) {
           get().deleteDraft(state.activeDraftId);
         } else {
-          set({ ...initialWizardFields, lastSavedAt: null, isDirty: false, activeDraftId: null });
+          set({ ...initialWizardFields, lastSavedAt: null, isDirty: false, activeDraftId: null, activeDraftOwner: null });
         }
       },
       reset: () => {
@@ -410,7 +414,7 @@ export const useWizardStore = create<WizardState & WizardActions>()(
       },
 
       // Multi-draft actions
-      startNewDraft: () => {
+      startNewDraft: (userId?: string) => {
         const state = get();
         const now = new Date().toISOString();
         let drafts = { ...state.savedDrafts };
@@ -428,6 +432,7 @@ export const useWizardStore = create<WizardState & WizardActions>()(
           ...initialWizardFields,
           lastSavedAt: null,
           isDirty: false,
+          activeDraftOwner: userId ?? state.activeDraftOwner ?? null,
           activeDraftId: newId,
           savedDrafts: drafts,
         });
@@ -471,6 +476,7 @@ export const useWizardStore = create<WizardState & WizardActions>()(
             lastSavedAt: null,
             isDirty: false,
             activeDraftId: null,
+            activeDraftOwner: null,
             savedDrafts: remaining,
           });
         } else {

--- a/game-over-app/supabase/migrations/20260315000000_invite_codes_guest_fields.sql
+++ b/game-over-app/supabase/migrations/20260315000000_invite_codes_guest_fields.sql
@@ -1,0 +1,8 @@
+-- Migration: Add guest contact fields to invite_codes
+-- These allow pre-filling the signup form when a guest enters their invite code.
+
+ALTER TABLE invite_codes
+  ADD COLUMN IF NOT EXISTS guest_first_name TEXT,
+  ADD COLUMN IF NOT EXISTS guest_last_name  TEXT,
+  ADD COLUMN IF NOT EXISTS guest_email      TEXT,
+  ADD COLUMN IF NOT EXISTS guest_phone      TEXT;

--- a/game-over-app/supabase/migrations/20260316000000_invite_preview_rpc.sql
+++ b/game-over-app/supabase/migrations/20260316000000_invite_preview_rpc.sql
@@ -1,0 +1,61 @@
+-- Migration: SECURITY DEFINER RPC for invite preview
+-- Anonymous users cannot SELECT from events (RLS requires auth.uid() = created_by).
+-- This function bypasses RLS safely and returns only the data needed for the invite preview.
+
+CREATE OR REPLACE FUNCTION get_invite_preview(p_code TEXT)
+RETURNS TABLE (
+  event_id        UUID,
+  event_title     TEXT,
+  honoree_name    TEXT,
+  city_name       TEXT,
+  city_id         UUID,
+  start_date      TEXT,
+  organizer_name  TEXT,
+  accepted_count  BIGINT,
+  expires_at      TIMESTAMPTZ,
+  max_uses        INTEGER,
+  use_count       INTEGER,
+  guest_first_name TEXT,
+  guest_last_name  TEXT,
+  guest_email      TEXT,
+  guest_phone      TEXT
+)
+LANGUAGE SQL
+SECURITY DEFINER   -- runs as DB owner, bypasses RLS on all joined tables
+SET search_path = public
+AS $$
+  SELECT
+    e.id                                                          AS event_id,
+    COALESCE(e.title, e.honoree_name || '''s Party')              AS event_title,
+    e.honoree_name,
+    c.name                                                        AS city_name,
+    e.city_id,
+    e.start_date::TEXT                                            AS start_date,
+    COALESCE(p.full_name, 'The organizer')                        AS organizer_name,
+    (
+      SELECT COUNT(*)::BIGINT
+      FROM   event_participants ep
+      WHERE  ep.event_id = e.id
+        AND  ep.role = 'guest'
+        AND  ep.confirmed_at IS NOT NULL
+    )                                                             AS accepted_count,
+    ic.expires_at,
+    ic.max_uses,
+    ic.use_count,
+    ic.guest_first_name,
+    ic.guest_last_name,
+    ic.guest_email,
+    ic.guest_phone
+  FROM  invite_codes ic
+  JOIN  events   e ON e.id  = ic.event_id
+  LEFT  JOIN cities   c ON c.id  = e.city_id
+  LEFT  JOIN profiles p ON p.id  = e.created_by
+  WHERE ic.code      = upper(p_code)
+    AND ic.is_active = true
+    AND (ic.expires_at IS NULL OR ic.expires_at > NOW())
+    AND (ic.max_uses  IS NULL OR ic.use_count < ic.max_uses)
+  LIMIT 1;
+$$;
+
+-- Allow both anonymous and authenticated users to call this function
+GRANT EXECUTE ON FUNCTION get_invite_preview(TEXT) TO anon, authenticated;

--- a/game-over-app/supabase/migrations/20260316000001_event_participants_guest_insert.sql
+++ b/game-over-app/supabase/migrations/20260316000001_event_participants_guest_insert.sql
@@ -1,0 +1,8 @@
+-- Allow authenticated users to insert themselves as event participants
+-- This is needed when accepting an invite via invite code.
+-- The is_event_creator ALL policy covers organizers; guests have no INSERT policy.
+-- Auth check: user can only add themselves (auth.uid() = user_id).
+
+CREATE POLICY "Users can join events as participant"
+  ON event_participants FOR INSERT
+  WITH CHECK (auth.uid() = user_id);

--- a/game-over-app/supabase/migrations/20260316000002_increment_invite_use_count.sql
+++ b/game-over-app/supabase/migrations/20260316000002_increment_invite_use_count.sql
@@ -1,0 +1,16 @@
+-- Atomically increment the use_count on an invite code after acceptance.
+-- Called via RPC from the client so we can catch missing-function errors gracefully.
+
+CREATE OR REPLACE FUNCTION public.increment_invite_use_count(invite_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE invite_codes
+  SET use_count = COALESCE(use_count, 0) + 1
+  WHERE id = invite_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.increment_invite_use_count(UUID) TO authenticated;

--- a/game-over-app/supabase/migrations/20260317000000_profiles_add_phone.sql
+++ b/game-over-app/supabase/migrations/20260317000000_profiles_add_phone.sql
@@ -1,0 +1,4 @@
+-- Add phone column to profiles table
+-- Required for storing guest phone numbers collected during invite wizard onboarding
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS phone TEXT;

--- a/game-over-app/supabase/migrations/20260317000001_polls_allow_participants_insert.sql
+++ b/game-over-app/supabase/migrations/20260317000001_polls_allow_participants_insert.sql
@@ -1,0 +1,15 @@
+-- Allow any event participant (not just organizers) to create polls
+-- The previous policy restricted poll creation to organizers only.
+
+DROP POLICY IF EXISTS "Event organizers can create polls" ON polls;
+
+CREATE POLICY "Event participants can create polls"
+  ON polls FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    created_by = auth.uid() AND
+    event_id IN (
+      SELECT event_id FROM event_participants
+      WHERE user_id = auth.uid()
+    )
+  );

--- a/game-over-app/supabase/migrations/20260321000002_fix_cron_auth.sql
+++ b/game-over-app/supabase/migrations/20260321000002_fix_cron_auth.sql
@@ -1,0 +1,48 @@
+-- Fix cron job authentication
+--
+-- Both edge functions (process-payment-reminders, send-final-briefing) were updated to
+-- require a CRON_SECRET bearer token instead of the service role key, as a defence-in-depth
+-- measure (service role key should never travel over HTTP headers unnecessarily).
+--
+-- This migration replaces both cron jobs to send CRON_SECRET from Vault.
+--
+-- PREREQUISITE: Before applying this migration, store CRON_SECRET in Supabase Vault:
+--   Supabase Dashboard → Vault → New Secret → name: "CRON_SECRET", value: <random secret>
+-- And set the same value as a function secret:
+--   npx supabase secrets set CRON_SECRET=<same value> --project-ref stdbvehmjpmqbjyiodqg
+
+-- Replace process-payment-reminders cron job
+SELECT cron.unschedule('process-payment-reminders');
+SELECT cron.schedule(
+  'process-payment-reminders',
+  '0 9 * * *', -- 9:00 AM UTC daily
+  $$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'SUPABASE_URL')
+           || '/functions/v1/process-payment-reminders',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- Replace send-final-briefing cron job
+SELECT cron.unschedule('send-final-briefing-daily');
+SELECT cron.schedule(
+  'send-final-briefing-daily',
+  '0 9 * * *', -- 9:00 AM UTC daily
+  $$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'SUPABASE_URL')
+           || '/functions/v1/send-final-briefing',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET')
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);


### PR DESCRIPTION
## Summary

This PR delivers all Tier 3 UX/Design fixes identified in the 5-tier codebase analysis, plus supporting quality improvements from earlier sessions.

### 🎨 Dark Theme Fixes (Critical)
- **polls.tsx**: Replace all `colors.light.*` with `DARK_THEME.*` — filter chips and buttons were visually broken (white-on-dark)
- **ChannelListItem, CreatePollModal, SocialButton**: Additional `colors.light.*` violations found during final audit, fixed in the same sweep

### 🎨 Color Unification
- **#258CF4 → #5A7EB0** across 8 files (GlassPanel, Badge, spacing.ts, usePushNotifications, confirmation, payment, review, package detail)
- **#4A6FA5 → #5A7EB0** across 5 files (communication, notifications, Toggle, PollCard, AvatarUpload)
- Back arrow in polls.tsx was `#1A202C` (near-black, invisible on dark header) → `DARK_THEME.textPrimary`

### 🐛 UX Bug Fixes
- **Invite flow**: Persistent "Already have an account? Log in →" link always visible below signup form (previously only shown after triggering an email error)
- **Invite Decline crash**: `router.back()` with no history exits the app on cold-start — fixed with `router.canGoBack()` guard
- **Event Detail**: Added network error state with "Try Again" retry button (previously showed blank loading state indefinitely on network failure)
- **Guest payment handler**: Supabase `.update()` response was not checked for errors — now throws `updateError` properly

### 🏗️ Architecture / Design System
- **Tab bar visibility**: Removed fragile recursive `routeHasEventId` route inspector; replaced with `useTabBarStore` focus effects (chat now mirrors budget's existing pattern). Added safety reset on `TabsLayout` mount to prevent stuck-hidden state
- **IconCircle component**: Extracted `src/components/ui/IconCircle.tsx` — shared 32px icon-in-circle used 30+ times across the app; migrated GlassPanel as proof-of-concept
- **CARD_VARIANTS**: Added named card style variants to `theme.ts` (`card`, `glassCard`, `deepCard`) with usage documentation

### 📦 Quality / Infrastructure (from earlier sessions)
- **storage.ts**: MMKV `require()` moved to module level (was dynamic inside function bodies)
- **app.config.ts**: `assetBundlePatterns` restricted to image extensions only (excludes `assets/store/*.md`, `*.txt`)
- **budget/index.tsx**: 20 `useState` calls consolidated into 4 grouped objects; hardcoded Alert strings replaced with i18n keys
- **i18n (en/de)**: Added `budget`, `notifications`, and `eventDetail` translation keys
- **GO_LIVE_CHECKLIST.md**: Added migrations, edge function deploy, and Supabase secrets sections

### 🗄️ Pending DB Migrations
7 migration files ready for `npx supabase db push`:
- `20260315000000_invite_codes_guest_fields`
- `20260316000000_invite_preview_rpc`
- `20260316000001_event_participants_guest_insert`
- `20260316000002_increment_invite_use_count`
- `20260317000000_profiles_add_phone`
- `20260317000001_polls_allow_participants_insert`
- `20260321000002_fix_cron_auth` ← fixes cron jobs sending wrong auth token

## Test plan

- [ ] Open Polls screen on a real device — filter chips should have dark background, not white
- [ ] Open invite link cold (no app history) → tap Decline → should navigate to Events, not crash
- [ ] Open invite link → see signup form → "Already have an account? Log in →" visible before any error
- [ ] Navigate to an event with no network → Event Detail shows error state with retry button
- [ ] Tab to Chat from an event summary → tab bar hidden; navigate back → tab bar visible
- [ ] Color audit: no `#258CF4`, `#4A6FA5`, or `colors.light.*` anywhere in app/ or src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)